### PR TITLE
FE: [feat] Toast Implementation

### DIFF
--- a/src/shared/components/Toast/useToast.tsx
+++ b/src/shared/components/Toast/useToast.tsx
@@ -1,0 +1,88 @@
+'use client'
+import { ReactNode } from 'react';
+
+import styled from '@emotion/styled'
+import LucideIcon from '@shared/lib/ui/LucideIcon'
+import { theme } from '@shared/styles/theme'
+
+export interface ToastProps {
+    isSuccess: boolean
+    message: string
+    onClose?: () => void
+  }
+
+const Component = ({ isSuccess, message, onClose }: ToastProps): ReactNode => {
+  const iconName = isSuccess ? 'CheckCheck' : 'CircleAlert'
+
+  return (
+    <Container success={isSuccess}>
+      <Wrapper>
+        <LucideIcon
+          name={iconName}
+          size={20}
+          color={isSuccess ? 'lfBlack' : 'lfRed'}
+        />
+      </Wrapper>
+      <Message>{message}</Message>
+      {onClose && (
+        <CloseIcon onClick={onClose}>
+          <LucideIcon name="X" size={16} color="lfBlack" />
+        </CloseIcon>
+      )}
+    </Container>
+  );
+};
+
+export default Component;
+
+/*-----스타일-------*/
+const Container = styled.div<{ success: boolean }>`
+  position: fixed;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  letter-spacing: 0.02em;
+  
+  z-index: 100;
+  left: 50%;
+  transform: translateX(-50%);
+
+  min-width: ${({success}) => success
+    ? '209px'
+    : '256px'
+  };
+  height: 30px;
+  padding: 25px 20px;
+
+  background-color: ${theme.colors.lfWhite.base};
+  /* border: 1px solid
+    ${({ success }) => success
+      ? theme.colors.lfGreenMain.base
+      : theme.colors.lfRed.base
+    }; */
+  border-radius: ${theme.radius.base};
+  color: ${({ success }) =>
+    success
+      ? theme.colors.lfBlack.base
+      : theme.colors.lfRed.base};
+  font-size: ${({success}) => success
+    ? theme.fontSize.sm
+    : theme.fontSize.xs
+  };
+`
+const Wrapper = styled.div`
+    display: flex;
+    align-self: center;
+`
+
+const Message = styled.span`
+  flex: 1;
+  white-space: pre-line;
+`
+
+const CloseIcon = styled.div`
+  position: absolute;
+  right: 7px;
+  top: 4px;
+  cursor: pointer;
+`

--- a/src/shared/components/Toast/useToast.tsx
+++ b/src/shared/components/Toast/useToast.tsx
@@ -42,7 +42,7 @@ const Container = styled.div<{ success: boolean }>`
   align-items: center;
   text-align: center;
   letter-spacing: 0.02em;
-  
+
   z-index: 100;
   left: 50%;
   transform: translateX(-50%);
@@ -65,10 +65,12 @@ const Container = styled.div<{ success: boolean }>`
     success
       ? theme.colors.lfBlack.base
       : theme.colors.lfRed.base};
+
   font-size: ${({success}) => success
     ? theme.fontSize.sm
     : theme.fontSize.xs
   };
+  font-weight: ${theme.fontWeight.medium};
 `
 const Wrapper = styled.div`
     display: flex;


### PR DESCRIPTION
### 관련 이슈

Relates to #17 
Closes #38 

## 주요 변경사항

### 1. Toast의 상태가 2개이기 때문에 분할하지 않고 props로 값을 받아서 표시되도록 하였습니다.
```
{showToast && (
        <Toast
          isSuccess={true}
          message="성공적으로 저장되었습니다!"
          onClose={() => setShowToast(false)}
        />
)}
```
isSuccess가 true일 때
![image](https://github.com/user-attachments/assets/467831a3-e044-4525-b151-216ea90a94e5)
isSuccess가 false일 때
![image](https://github.com/user-attachments/assets/58b295b7-2a83-4d0d-b57b-fa7629040fa8)
만약 2줄 이상의 내용이 들어간다면 다음과 같이 \n을 사용해서 줄바꿈합니다.
```
{showToast && (
        <Toast
          isSuccess={false}
          message="오류가 발생하였습니다!\n다시 시도해주세요"
          onClose={() => setShowToast(false)}
        />
)}
```
또한, 기본적으로 Toast 창은 스크롤을 막거나 하는 경우를 보지 못했기 때문에 커스텀 훅을 적용하지 않았으나,
요구 사항이 생긴다면 바로 수정할 수 있습니다!
### PR간 오류 혹은 질문은 댓글로 남겨주세요!
