### PR TITLE
FE: PR[feat] GridBox Implementation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 
-import ConfirmModal from '@shared/components/modal/ConfirmModal'
+import ConfirmModal from '@shared/components/Modal/ConfirmModal'
 import { Providers } from '@shared/config/providers/Providers'
 import GlobalScrollbarStyle from '@shared/styles/scrollbar/GlobalScrollbarStyle'
 

--- a/src/shared/components/Wrapper/GridBox.tsx
+++ b/src/shared/components/Wrapper/GridBox.tsx
@@ -1,0 +1,70 @@
+import { ReactNode } from 'react'
+import { Grid, GridProps } from '@chakra-ui/react'
+
+export interface GridBoxProps extends Omit<
+  GridProps,
+  'display' | 'templateColumns'
+> {
+  /** 자식 요소들(ReactNode 배열) */
+  children: ReactNode[]
+  /** 열 개수 (none 이면 auto-fit/minmax 사용)이기 때문에 */
+  columns?: number
+  /** 고정 너비 기반 동적 컬럼 (auto-fit/minmax) */
+  childWidth?: string
+  /** 행 간격 */
+  rowGap?: GridProps['rowGap']
+  /** 열 간격 */
+  columnGap?: GridProps['columnGap']
+  /** 아이템 수평 정렬 */
+  justifyItems?: GridProps['justifyItems']
+  /** 아이템 수직 정렬 */
+  alignItems?: GridProps['alignItems']
+  /** 그리드 컨테이너 수평 정렬 */
+  justifyContent?: GridProps['justifyContent']
+  /** 그리드 컨테이너 수직 정렬 */
+  alignContent?: GridProps['alignContent']
+  /** 자동 배치 흐름 */
+  autoFlow?: GridProps['gridAutoFlow']
+  /** 행 레이아웃 템플릿 (필요 시) */
+  templateRows?: GridProps['templateRows']
+}
+
+const GridBox = ({
+  children,
+  columns,
+  childWidth,
+  rowGap,
+  columnGap,
+  justifyItems,
+  alignItems,
+  justifyContent,
+  alignContent,
+  autoFlow,
+  templateRows,
+  ...rest
+}: GridBoxProps) => {
+  // childWidth 가 주어지면 auto-fit/minmax, 없으면 repeat(columns, max-content)
+  const templateColumns = childWidth
+    ? `repeat(auto-fit, minmax(${childWidth}, 1fr))`
+    : `repeat(${columns ?? 1}, max-content)`
+
+  return (
+    <Grid
+      display="inline-grid"
+      templateColumns={templateColumns}
+      templateRows={templateRows}
+      rowGap={rowGap}
+      columnGap={columnGap}
+      justifyItems={justifyItems}
+      alignItems={alignItems}
+      justifyContent={justifyContent}
+      alignContent={alignContent}
+      gridAutoFlow={autoFlow}
+      {...rest}
+    >
+      {children}
+    </Grid>
+  )
+}
+
+export default GridBox

--- a/src/shared/components/Wrapper/GridBox.tsx
+++ b/src/shared/components/Wrapper/GridBox.tsx
@@ -1,13 +1,10 @@
 import { ReactNode } from 'react'
 import { Grid, GridProps } from '@chakra-ui/react'
 
-export interface GridBoxProps extends Omit<
-  GridProps,
-  'display' | 'templateColumns'
-> {
+export interface GridBoxProps extends Omit<GridProps, 'display' | 'templateColumns'> {
   /** 자식 요소들(ReactNode 배열) */
   children: ReactNode[]
-  /** 열 개수 (none 이면 auto-fit/minmax 사용)이기 때문에 */
+  /** 열 개수 (none 이면 auto-fit/minmax 사용) */
   columns?: number
   /** 고정 너비 기반 동적 컬럼 (auto-fit/minmax) */
   childWidth?: string
@@ -50,7 +47,7 @@ const GridBox = ({
 
   return (
     <Grid
-      display="inline-grid"
+      display='inline-grid'
       templateColumns={templateColumns}
       templateRows={templateRows}
       rowGap={rowGap}

--- a/src/shared/config/providers/ChakraProvider.tsx
+++ b/src/shared/config/providers/ChakraProvider.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react'
+
+import { ChakraProvider, defaultSystem } from '@chakra-ui/react'
+
+/**
+ * Chakra UI의 Provider
+ */
+export function ChakraUseProvider({ children }: { children: ReactNode }) {
+  return <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+}

--- a/src/shared/config/providers/Providers.tsx
+++ b/src/shared/config/providers/Providers.tsx
@@ -3,11 +3,12 @@
 import { ReactNode } from 'react'
 
 import { EmotionCacheProvider } from './EmotionCacheProvider'
+import { ChakraUseProvider } from './ChakraProvider'
 
 /**
  * 전역 Layout.tsx에 지정되는 Provider를 모아두는 저장소입니다.
  * 동일 경로에 Provider를 생성 후, 적용해주세요
  */
 export function Providers({ children }: { children: ReactNode }) {
-  return <EmotionCacheProvider>{children}</EmotionCacheProvider>
+  return <EmotionCacheProvider><ChakraUseProvider>{children}</ChakraUseProvider></EmotionCacheProvider>
 }


### PR DESCRIPTION
### 관련 이슈

Relates to #17 

## 주요 변경사항

### 1. Chakra UI를 사용하려면 ChakraProvider가 애플리케이션의 전역에 덮여 있어야 하므로 다음과 같이 추가했습니다.
```
export function Providers({ children }: { children: ReactNode }) {
  return <EmotionCacheProvider><ChakraUseProvider>{children}</ChakraUseProvider></EmotionCacheProvider>
}
```
### 2. 위와 같은 이유로ChakraProvide 파일이 추가되었습니다.
### 3. GridBox  import 를 통해서 Grid 레이아웃 사용이 가능합니다.
```
<GridBox columns={2} rowGap="10px" columnGap="10px">
   {items}
</GridBox>
```
### columns = {2}
![image](https://github.com/user-attachments/assets/6f3cb29c-53c0-4d55-b8f6-c44b1c8f4ad4)
### columns = {3}
![image](https://github.com/user-attachments/assets/7e483b5e-0f46-408c-b8bb-9f07f223ec19)
또한, rowGap과 columnGap을 사용해서 item간의 가로세로 거리를 조절할 수있습니다.

### 4. GridBox props
Chakra UI의 GridProps는 다음과 같은 데이터가 제공됩니다. 필요할 시 사용 가능합니다. 필요 시, 사용 가능합니다.
childWidth를 사용 시, auto-fit이 되어 혼란이 발생할 수 있으니, child item의 width를 설정하고 사용하는 것을 권장합니다.
```
 /** 고정 너비 기반 동적 컬럼 (auto-fit/minmax) */ 
  childWidth?: string 
  /** 아이템 수평 정렬 */
  justifyItems?: GridProps['justifyItems']
  /** 아이템 수직 정렬 */
  alignItems?: GridProps['alignItems']
  /** 그리드 컨테이너 수평 정렬 */
  justifyContent?: GridProps['justifyContent']
  /** 그리드 컨테이너 수직 정렬 */
  alignContent?: GridProps['alignContent']
  /** 자동 배치 흐름 */
  autoFlow?: GridProps['gridAutoFlow']
  /** 행 레이아웃 템플릿*/
  templateRows?: GridProps['templateRows']
```
### 5. onClickItem의 부재
처음 설계는 자식 컴포넌트를 클릭했을 때 이벤트 핸들러를 받아오고자 했지만, 단일 책임과 재사용성에 의거하여 제외했습니다.
### PR간 오류 혹은 질문은 댓글로 남겨주세요!
