### PR TITLE
FE: feat useImageUpload Implementation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,23 @@
-import type { NextConfig } from 'next'
+// import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {
-  /* config options here */
+// const nextConfig: NextConfig = {
+//   /* config options here */
+// }
+
+// export default nextConfig
+
+// next.config.js
+;/ @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'storage.googleapis.com', // 정확히 이 도메인이어야 함
+        pathname: '/leafresh-images/', // 해당 경로 하위 모든 이미지 허용
+      },
+    ],
+  },
 }
 
-export default nextConfig
+module.exports = nextConfig

--- a/src/features/member/api/signup.ts
+++ b/src/features/member/api/signup.ts
@@ -10,7 +10,7 @@ type SignUpResponseType = ApiResponse<{
   isDuplicated: boolean
 }>
 
-type SignUpBody = {
+export type SignUpBody = {
   email: string
   provider: {
     name: OAuthType

--- a/src/shared/components/Toast/Toast.tsx
+++ b/src/shared/components/Toast/Toast.tsx
@@ -7,7 +7,7 @@ import styled from '@emotion/styled'
 import { useToastStore } from '@shared/context/Toast/ToastStore'
 import { ToastType } from '@shared/context/Toast/type'
 import LucideIcon from '@shared/lib/ui/LucideIcon'
-import { theme } from '@shared/styles/emotion/theme'
+import { theme } from '@shared/styles/theme'
 
 const Toast = () => {
   const { isOpen, type, description, close: closeToast } = useToastStore()

--- a/src/shared/components/switchtap/SwitchTap.tsx
+++ b/src/shared/components/switchtap/SwitchTap.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import styled from '@emotion/styled'
 
-import { theme } from '@shared/styles/emotion/theme'
+import { theme } from '@shared/styles/theme'
 
 export interface SwitchTapProps {
   //탭의 수(제목들)

--- a/src/shared/components/timepicker/TimeDropdown.tsx
+++ b/src/shared/components/timepicker/TimeDropdown.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useEffect,useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import styled from '@emotion/styled'
 
-import { theme } from '@shared/styles/emotion/theme'
+import { theme } from '@shared/styles/theme'
 
 export interface TimeDropdownProps {
   value: string

--- a/src/shared/constants/endpoint/endpoint.ts
+++ b/src/shared/constants/endpoint/endpoint.ts
@@ -161,16 +161,15 @@ const MEMBER_ENDPOINTS = {
     },
   },
 }
-/**
- * DEPRECATED
+
+// DEPRECATED
 const S3_ENDPOINTS = {
   // 이미지 업로드용 Presigned URL 요청
   PRESIGNED_URL: { method: HttpMethod.POST, path: '/s3/images/presigned-url' },
 
-  // 이미지 실제 업로드 (PUT)
-  UPLOAD: { method: HttpMethod.PUT, path: '/s3/images' },
+  // 이미지 실제 업로드 (PUT) - Presigned Url을 사용
+  // UPLOAD: { method: HttpMethod.PUT, path: '/s3/images' },
 }
- */
 
 /** 게시글 (v2 개발)*/
 // const POST_ENDPOINTS = {
@@ -339,5 +338,6 @@ export const ENDPOINTS = {
   // POSTS: POST_ENDPOINTS,
   STORE: STORE_ENDPOINTS,
   CHATBOT: CHATBOT_ENDPOINTS,
+  S3: S3_ENDPOINTS,
   // ADMIN: ADMIN_ENDPOINTS,
 } as const

--- a/src/shared/hooks/useImageUpload/useImageUpload.ts
+++ b/src/shared/hooks/useImageUpload/useImageUpload.ts
@@ -38,7 +38,6 @@ export function useImageUpload() {
       if (!res.ok) throw new Error(`GCS 업로드 실패: ${res.status}`)
 
       // 3) 최종 공개 URL 조립
-      const bucket = process.env.NEXT_PUBLIC_GCS_BUCKET_NAME!
       // GCS 기본 공개 URL 패턴: https://storage.googleapis.com/[BUCKET]/[OBJECT_NAME]
       return signed.data.fileUrl
     } catch (err: any) {

--- a/src/shared/hooks/useImageUpload/useImageUpload.ts
+++ b/src/shared/hooks/useImageUpload/useImageUpload.ts
@@ -1,0 +1,53 @@
+import { useState, useCallback } from 'react'
+import { HttpMethod } from '@shared/constants/http'
+import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
+import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+
+type signedUrlResponse = ApiResponse<{
+  uploadUrl: string // GCS로 PUT 요청을 보낼 PreSigned URL
+  fileUrl: string // 버킷 내부에 저장될 객체 경로 (key)
+}>
+
+export function useImageUpload() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  const uploadFile = useCallback(async (file: File): Promise<string> => {
+    setLoading(true)
+    setError(null)
+    const uniqueId = crypto.randomUUID()
+    const uniqueName = `${Date.now()}-${uniqueId}-${file.name}`
+
+    try {
+      const signed = await fetchRequest<signedUrlResponse>(ENDPOINTS.S3.PRESIGNED_URL, {
+        body: {
+          fileName: uniqueName,
+          contentType: file.type,
+        },
+      })
+      console.log(signed)
+      console.log(file.name)
+      // 2) GCS에 PUT 요청으로 업로드
+      console.log(signed.data.uploadUrl)
+      console.log(signed.data.fileUrl)
+      const res = await fetch(signed.data.uploadUrl, {
+        method: HttpMethod.PUT,
+        headers: { 'Content-Type': file.type },
+        body: file,
+      })
+      if (!res.ok) throw new Error(`GCS 업로드 실패: ${res.status}`)
+
+      // 3) 최종 공개 URL 조립
+      const bucket = process.env.NEXT_PUBLIC_GCS_BUCKET_NAME!
+      // GCS 기본 공개 URL 패턴: https://storage.googleapis.com/[BUCKET]/[OBJECT_NAME]
+      return signed.data.fileUrl
+    } catch (err: any) {
+      setError(err)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  return { uploadFile, loading, error }
+}

--- a/src/shared/hooks/useImageUpload/useImageUpload.ts
+++ b/src/shared/hooks/useImageUpload/useImageUpload.ts
@@ -25,11 +25,7 @@ export function useImageUpload() {
           contentType: file.type,
         },
       })
-      console.log(signed)
-      console.log(file.name)
       // 2) GCS에 PUT 요청으로 업로드
-      console.log(signed.data.uploadUrl)
-      console.log(signed.data.fileUrl)
       const res = await fetch(signed.data.uploadUrl, {
         method: HttpMethod.PUT,
         headers: { 'Content-Type': file.type },


### PR DESCRIPTION
# 🍀 무엇을 위한 PR인가요?

이미지 업로드 훅 구현

-

## 관련 이슈

Relates to #65
Closes #69 

# 주요 변경사항

## 1. GCS에 이미지 업로드 후 이미지 URL을 반환하는 훅을 구현했습니다.

## 2. 파일 이름이 겹치면 최초의 이미지만 불러오는 이슈 해결
```
    const uniqueId = crypto.randomUUID()
    const uniqueName = `${Date.now()}-${uniqueId}-${file.name}`

    try {
      const signed = await fetchRequest<signedUrlResponse>(ENDPOINTS.S3.PRESIGNED_URL, {
        body: {
          fileName: uniqueName,
          contentType: file.type,
        },
      })
```
Node.js에서 제공해주는 랜덤 값 생성과, 현재 timestamp를 파일 이름에 붙여 presigned url을 받아오는 방법으로 해결했습니다.

## 3. 사용
```
// loading은 boolean 값으로 업로드 중이면 true, 업로드가 완료되면 false
const { uploadFile, loading, error } = useImageUpload()
const [imageUrl, setImageUrl] = useState<string | null>(null)

try {
      // 파일 업로드 → 공개 URL 반환
      const url = await uploadFile(file)
      setImageUrl(url) //원하는 방식으로 적재
    } catch {
      // 에러는 훅의 error 상태에 setting 되어 있음
      console.error(error)
    }
  }

```


### PR간 오류 혹은 질문은 댓글로 남겨주세요!
