### PR TITLE
PR [fix] 카메라 모달 전후면 전환 및 사용 에러 핸들링

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 
 import ModalProvider from '@shared/components/modal/ModalProvider'
-import Toast from '@shared/components/Toast/Toast'
+import Toast from '@shared/components/toast/Toast'
 import ImageZoomModal from '@shared/components/zoommodal/ImageZoomModal/ImageZoomModal'
 import { pretendard } from '@shared/config/font'
 import { Providers } from '@shared/config/providers/Providers'


### PR DESCRIPTION
# 🍀 무엇을 위한 PR인가요?

- 카메라 관련 에러 코드 수정

## 관련 이슈

Relates to #76 
Closes #90 

# 주요 변경사항

## 1. 카메라 후면 전환
``` typescript
  // 카메라 초기화 및 정리 효과
  useEffect(() => {
    if (isOpen && !previewUrl) {
      setScrollTop(window.scrollY)
      startCamera()
    }

    return () => {
      // 컴포넌트 언마운트 또는 의존성 변경 시 항상 카메라 정리
      stopCamera()
    }
  }, [isOpen, previewUrl, facingMode]) //수정 전에는 isOpen만 의존성 배열에 존재
  ```
위의 useEffect코드에서 facingMode에 대한 의존성이 사라져서 생긴 문제였습니다.

## 2. 후면 전환 후 전면 카메라 전환 시 에러 발생 + 약간의 시간 지나면 전면 카메라 켜짐
``` typescript
  // facingMode 변경 시 카메라 재시작-> 같은 기능을 하는 useEffect가 충돌
  // useEffect(() => {
  //   if (isOpen && !previewUrl) {
  //     startCamera()
  //   }
  // }, [facingMode])
  ```
cameraModal 코드의 startCamera에서 전후면 전환 시에 카메라 정리 및 재시작을 하는데, 같은 기능의 useEffect가 2개 존재해서 생긴 문제였습니다. 해당 코드는 주석 처리하였습니다.
- 주요 변경점은 위의 2가지입니다.

### PR간 오류 혹은 질문은 댓글로 남겨주세요!
