### PR TITLE
FE: PR(refactor) fetchReqeust + useMutationStore 반환 타입 최적화

### DIFF
--- a/src/features/challenge/api/create-group-challenge.ts
+++ b/src/features/challenge/api/create-group-challenge.ts
@@ -1,15 +1,11 @@
 import { ChallengeCategoryType, ChallengeVerificationResultType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 import { DateFormatString, TimeFormatString } from '@shared/types/date'
 
-// TODO : isDuplicated -> isAvailable 로 변수명 저정
-/**
- * false: 사용 가능 / true 사용 불가능
- */
-export type CreateChallengeResponse = ApiResponse<{
+export type CreateChallengeResponse = {
   id: number
-}>
+}
 
 export type ExampleImageType = {
   imageUrl: string

--- a/src/features/challenge/api/get-event-challenge-list.ts
+++ b/src/features/challenge/api/get-event-challenge-list.ts
@@ -1,5 +1,5 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
 export type EventChallenge = {
   id: number
@@ -8,10 +8,10 @@ export type EventChallenge = {
   thumbnailUrl: string
 }
 
-type GetEventChallengeListResponse = ApiResponse<{
+type GetEventChallengeListResponse = {
   eventChallenges: EventChallenge[]
-}>
+}
 
-export const getEventChallengeList = (): Promise<GetEventChallengeListResponse> => {
+export const getEventChallengeList = () => {
   return fetchRequest<GetEventChallengeListResponse>(ENDPOINTS.CHALLENGE.EVENT.LIST)
 }

--- a/src/features/challenge/api/get-group-challenge-categories.ts
+++ b/src/features/challenge/api/get-group-challenge-categories.ts
@@ -1,6 +1,6 @@
 import { ChallengeCategoryType, ChallengeCategoryTypeKor } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
 export type GroupChallengeCategory = {
   category: ChallengeCategoryType
@@ -8,10 +8,10 @@ export type GroupChallengeCategory = {
   imageUrl: string
 }
 
-type GroupChallengeCategoryListResponse = ApiResponse<{
+type GroupChallengeCategoryListResponse = {
   categories: GroupChallengeCategory[]
-}>
+}
 
-export const getGroupChallengeCategoryList = (): Promise<GroupChallengeCategoryListResponse> => {
+export const getGroupChallengeCategoryList = () => {
   return fetchRequest<GroupChallengeCategoryListResponse>(ENDPOINTS.CHALLENGE.GROUP.CATEGORIES)
 }

--- a/src/features/challenge/api/get-group-challenge-details.ts
+++ b/src/features/challenge/api/get-group-challenge-details.ts
@@ -6,7 +6,7 @@ import {
   ChallengeVerificationStatusType,
 } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 import { DateFormatString, TimeFormatString } from '@shared/types/date'
 
 export type GroupChallengeDetail = {
@@ -34,8 +34,8 @@ export type GroupChallengeDetail = {
   status: ChallengeVerificationStatusType
 }
 
-type GetGroupChallengeDetailResponse = ApiResponse<GroupChallengeDetail>
+type GetGroupChallengeDetailResponse = GroupChallengeDetail
 
-export const getGroupChallengeDetails = (id: number): Promise<GetGroupChallengeDetailResponse> => {
+export const getGroupChallengeDetails = (id: number) => {
   return fetchRequest<GetGroupChallengeDetailResponse>(ENDPOINTS.CHALLENGE.GROUP.DETAILS(id))
 }

--- a/src/features/challenge/api/get-group-challenge-list.ts
+++ b/src/features/challenge/api/get-group-challenge-list.ts
@@ -1,5 +1,5 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
 /**
  * 요청 파라미터 타입
@@ -28,21 +28,20 @@ export interface GroupChallengeItem {
 /**
  * 응답 데이터 타입
  */
-export interface FetchGroupChallengesResponse
-  extends ApiResponse<{
-    groupChallenges: GroupChallengeItem[]
-    hasNext: boolean
-    cursorInfo: {
-      lastCursorId: number
-      cursorTimestamp: string
-    }
-  }> {}
+export type FetchGroupChallengesResponse = {
+  groupChallenges: GroupChallengeItem[]
+  hasNext: boolean
+  cursorInfo: {
+    lastCursorId: number
+    cursorTimestamp: string
+  }
+}
 
 /**
  * 단체 챌린지 목록 조회 (검색 및 카테고리 필터 포함)
  * GET /api/challenges/group?input=…&category=…&cursorId=…&cursorTimestamp=…
  */
-export const fetchGroupChallenges = (params: FetchGroupChallengesParams): Promise<FetchGroupChallengesResponse> => {
+export const fetchGroupChallenges = (params: FetchGroupChallengesParams) => {
   // query 객체에 undefined 값은 제외하고 문자열/숫자 타입으로만 전환
   const query: Record<string, string | number> = {}
   if (params.category) query.category = params.category

--- a/src/features/challenge/api/get-group-challenge-list.ts
+++ b/src/features/challenge/api/get-group-challenge-list.ts
@@ -1,5 +1,6 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { InfiniteScrollResponse } from '@shared/types/api'
 
 /**
  * 요청 파라미터 타입
@@ -28,14 +29,9 @@ export interface GroupChallengeItem {
 /**
  * 응답 데이터 타입
  */
-export type FetchGroupChallengesResponse = {
+export type FetchGroupChallengesResponse = InfiniteScrollResponse<{
   groupChallenges: GroupChallengeItem[]
-  hasNext: boolean
-  cursorInfo: {
-    lastCursorId: number
-    cursorTimestamp: string
-  }
-}
+}>
 
 /**
  * 단체 챌린지 목록 조회 (검색 및 카테고리 필터 포함)

--- a/src/features/challenge/api/get-group-challenge-rules.ts
+++ b/src/features/challenge/api/get-group-challenge-rules.ts
@@ -1,6 +1,6 @@
 import { ChallengeVerificationResultType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 import { DateFormatString, TimeFormatString } from '@shared/types/date'
 
 type ExampleImageType = {
@@ -11,7 +11,7 @@ type ExampleImageType = {
   type: ChallengeVerificationResultType
 }
 
-export type GroupChallengeRulesListResponse = ApiResponse<{
+export type GroupChallengeRulesListResponse = {
   certificationPeriod: {
     startDate: DateFormatString
     endDate: DateFormatString
@@ -19,8 +19,8 @@ export type GroupChallengeRulesListResponse = ApiResponse<{
     endTime: TimeFormatString
   }
   exampleImages: ExampleImageType[]
-}>
+}
 
-export const getGroupChallengeRulesList = (challengeId: number): Promise<GroupChallengeRulesListResponse> => {
+export const getGroupChallengeRulesList = (challengeId: number) => {
   return fetchRequest<GroupChallengeRulesListResponse>(ENDPOINTS.CHALLENGE.GROUP.RULES(challengeId))
 }

--- a/src/features/challenge/api/get-personal-challenge-details.ts
+++ b/src/features/challenge/api/get-personal-challenge-details.ts
@@ -2,7 +2,7 @@
 
 import { ChallengeVerificationResultType, ChallengeVerificationStatusType, DayType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 import { TimeFormatString } from '@shared/types/date'
 
 export type PersonalChallengeDetail = {
@@ -24,8 +24,8 @@ export type PersonalChallengeDetail = {
   status: ChallengeVerificationStatusType
 }
 
-type PersonalChallengeDetailResponse = ApiResponse<PersonalChallengeDetail>
+type PersonalChallengeDetailResponse = PersonalChallengeDetail
 
-export const getPersonalChallengeDetails = (id: number): Promise<PersonalChallengeDetailResponse> => {
+export const getPersonalChallengeDetails = (id: number) => {
   return fetchRequest<PersonalChallengeDetailResponse>(ENDPOINTS.CHALLENGE.PERSONAL.DETAILS(id))
 }

--- a/src/features/challenge/api/get-personal-challenge-list.ts
+++ b/src/features/challenge/api/get-personal-challenge-list.ts
@@ -2,7 +2,7 @@
 
 import { DayType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
 type GetPersonalChallengeListQuery = {
   dayOfWeek: DayType
@@ -16,13 +16,11 @@ export type PersonalChallengeType = {
   leafReward: number
 }
 
-type GetPersonalChallengeListResponse = ApiResponse<{
+type GetPersonalChallengeListResponse = {
   personalChallenges: PersonalChallengeType[]
-}>
+}
 
-export const getPersonalChallengeList = (
-  query: GetPersonalChallengeListQuery,
-): Promise<GetPersonalChallengeListResponse> => {
+export const getPersonalChallengeList = (query: GetPersonalChallengeListQuery) => {
   return fetchRequest<GetPersonalChallengeListResponse>(ENDPOINTS.CHALLENGE.PERSONAL.LIST, {
     query,
   })

--- a/src/features/challenge/api/get-personal-challenge-rules.ts
+++ b/src/features/challenge/api/get-personal-challenge-rules.ts
@@ -1,6 +1,6 @@
 import { ChallengeVerificationResultType, DayType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 import { TimeFormatString } from '@shared/types/date'
 
 export type PersonalChallengeExampleImageType = {
@@ -11,15 +11,15 @@ export type PersonalChallengeExampleImageType = {
   type: ChallengeVerificationResultType
 }
 
-export type PersonalChallengeRulesListResponse = ApiResponse<{
+export type PersonalChallengeRulesListResponse = {
   certificationPeriod: {
     dayOfWeek: DayType
     startTime: TimeFormatString
     endTime: TimeFormatString
   }
   exampleImages: PersonalChallengeExampleImageType[]
-}>
+}
 
-export const getPersonalChallengeRulesList = (challengeId: number): Promise<PersonalChallengeRulesListResponse> => {
+export const getPersonalChallengeRulesList = (challengeId: number) => {
   return fetchRequest<PersonalChallengeRulesListResponse>(ENDPOINTS.CHALLENGE.PERSONAL.RULES(challengeId))
 }

--- a/src/features/challenge/api/participate-group-challenge.ts
+++ b/src/features/challenge/api/participate-group-challenge.ts
@@ -1,9 +1,9 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
-export type ParticipateGroupChallengeResponse = ApiResponse<{
+export type ParticipateGroupChallengeResponse = {
   id: number
-}>
+}
 
 export type ParticipateGroupChallengeVariables = {
   challengeId: number

--- a/src/features/challenge/api/participate/get-group-participant-list.ts
+++ b/src/features/challenge/api/participate/get-group-participant-list.ts
@@ -1,5 +1,6 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { InfiniteScrollResponse } from '@shared/types/api'
 import { ISOFormatString } from '@shared/types/date'
 
 export interface GroupChallengeParticipateListParams {
@@ -16,14 +17,9 @@ export type VerificationType = {
   description: string
 }
 
-export type GroupChallengeParticipateList = {
+export type GroupChallengeParticipateList = InfiniteScrollResponse<{
   items: VerificationType[]
-  hasNext: boolean
-  cursorInfo: {
-    lastCursorId: number
-    cursorTimestamp: ISOFormatString
-  }
-}
+}>
 
 type GetGroupChallengeParticipateListResponse = GroupChallengeParticipateList
 

--- a/src/features/challenge/api/participate/get-group-participant-list.ts
+++ b/src/features/challenge/api/participate/get-group-participant-list.ts
@@ -1,5 +1,5 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 import { ISOFormatString } from '@shared/types/date'
 
 export interface GroupChallengeParticipateListParams {
@@ -25,13 +25,13 @@ export type GroupChallengeParticipateList = {
   }
 }
 
-type GetGroupChallengeParticipateListResponse = ApiResponse<GroupChallengeParticipateList>
+type GetGroupChallengeParticipateListResponse = GroupChallengeParticipateList
 
 export const getGroupChallengeParticipateList = ({
   challengeId,
   cursorId,
   cursorTimestamp,
-}: GroupChallengeParticipateListParams): Promise<GetGroupChallengeParticipateListResponse> => {
+}: GroupChallengeParticipateListParams) => {
   return fetchRequest<GetGroupChallengeParticipateListResponse>(ENDPOINTS.CHALLENGE.GROUP.VERIFICATIONS(challengeId), {
     query: {
       ...(cursorId !== undefined ? { cursorId } : {}),

--- a/src/features/challenge/api/participate/group-participant-count.ts
+++ b/src/features/challenge/api/participate/group-participant-count.ts
@@ -17,6 +17,6 @@ export interface CountResponse {
  * 참여한 단체 챌린지 개수 조회
  * GET /api/members/challenges/group/participations/count
  */
-export const fetchGroupParticipationsCount = (): Promise<CountResponse> => {
-  return fetchRequest(ENDPOINTS.CHALLENGE.GROUP.COUNT)
+export const fetchGroupParticipationsCount = () => {
+  return fetchRequest<CountResponse>(ENDPOINTS.CHALLENGE.GROUP.COUNT)
 }

--- a/src/features/challenge/api/participate/group-participant-count.ts
+++ b/src/features/challenge/api/participate/group-participant-count.ts
@@ -1,15 +1,11 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
-export interface CountResponse {
-  status: number
-  message: string
-  data: {
-    count: {
-      notStarted: number
-      ongoing: number
-      completed: number
-    }
+export interface GroupParticipationsCount {
+  count: {
+    notStarted: number
+    ongoing: number
+    completed: number
   }
 }
 
@@ -18,5 +14,5 @@ export interface CountResponse {
  * GET /api/members/challenges/group/participations/count
  */
 export const fetchGroupParticipationsCount = () => {
-  return fetchRequest<CountResponse>(ENDPOINTS.CHALLENGE.GROUP.COUNT)
+  return fetchRequest<GroupParticipationsCount>(ENDPOINTS.CHALLENGE.GROUP.COUNT)
 }

--- a/src/features/challenge/api/participate/group-participant.ts
+++ b/src/features/challenge/api/participate/group-participant.ts
@@ -32,11 +32,7 @@ export interface ChallengeResponse {
   }
 }
 
-export const fetchGroupParticipations = ({
-  status,
-  cursorId,
-  cursorTimestamp,
-}: FetchGroupParticipationsParams): Promise<ChallengeResponse> => {
+export const fetchGroupParticipations = ({ status, cursorId, cursorTimestamp }: FetchGroupParticipationsParams) => {
   return fetchRequest(ENDPOINTS.MEMBERS.CHALLENGE.GROUP.PARTICIPATIONS, {
     query: {
       status,

--- a/src/features/challenge/api/participate/group-participant.ts
+++ b/src/features/challenge/api/participate/group-participant.ts
@@ -10,30 +10,26 @@ export interface FetchGroupParticipationsParams {
 }
 
 export interface ChallengeResponse {
-  status: number
-  message: string
-  data: {
-    challenges: Array<{
-      id: number
-      title: string
-      thumbnailUrl: string
-      startDate: string
-      endDate: string
-      achievement: {
-        success: number
-        total: number
-      }
-    }>
-    hasNext: boolean
-    cursorInfo: {
-      lastCursorId: number
-      cursorTimestamp: string
+  challenges: Array<{
+    id: number
+    title: string
+    thumbnailUrl: string
+    startDate: string
+    endDate: string
+    achievement: {
+      success: number
+      total: number
     }
+  }>
+  hasNext: boolean
+  cursorInfo: {
+    lastCursorId: number
+    cursorTimestamp: string
   }
 }
 
 export const fetchGroupParticipations = ({ status, cursorId, cursorTimestamp }: FetchGroupParticipationsParams) => {
-  return fetchRequest(ENDPOINTS.MEMBERS.CHALLENGE.GROUP.PARTICIPATIONS, {
+  return fetchRequest<ChallengeResponse>(ENDPOINTS.MEMBERS.CHALLENGE.GROUP.PARTICIPATIONS, {
     query: {
       status,
       ...(cursorId !== undefined ? { cursorId } : {}),

--- a/src/features/challenge/api/participate/group-participant.ts
+++ b/src/features/challenge/api/participate/group-participant.ts
@@ -1,5 +1,6 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { InfiniteScrollResponse } from '@shared/types/api'
 
 export type ChallengeStatus = 'not_started' | 'ongoing' | 'completed'
 
@@ -9,8 +10,8 @@ export interface FetchGroupParticipationsParams {
   cursorTimestamp?: string
 }
 
-export interface ChallengeResponse {
-  challenges: Array<{
+export type ChallengeResponse = InfiniteScrollResponse<{
+  challenges: {
     id: number
     title: string
     thumbnailUrl: string
@@ -20,13 +21,8 @@ export interface ChallengeResponse {
       success: number
       total: number
     }
-  }>
-  hasNext: boolean
-  cursorInfo: {
-    lastCursorId: number
-    cursorTimestamp: string
-  }
-}
+  }[]
+}>
 
 export const fetchGroupParticipations = ({ status, cursorId, cursorTimestamp }: FetchGroupParticipationsParams) => {
   return fetchRequest<ChallengeResponse>(ENDPOINTS.MEMBERS.CHALLENGE.GROUP.PARTICIPATIONS, {

--- a/src/features/challenge/api/participate/verification/group-verification-list.ts
+++ b/src/features/challenge/api/participate/verification/group-verification-list.ts
@@ -1,11 +1,11 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
 /**
  * 단체 챌린지 참여자의 일별 인증 내역 조회
  * GET /api/members/challenges/group/participations/{challengeId}/verifications
  */
-export type GetGroupVerificationsResponse = ApiResponse<{
+export type GetGroupVerificationsResponse = {
   id: number
   title: string
   achievement: {
@@ -19,7 +19,7 @@ export type GetGroupVerificationsResponse = ApiResponse<{
     status: 'SUCCESS' | 'FAILURE' | 'PENDING_APPROVAL'
   }>
   todayStatus: 'NOT_SUBMITTED' | 'PENDING_APPROVAL' | 'DONE'
-}>
+}
 
-export const getGroupVerifications = (challengeId: number): Promise<GetGroupVerificationsResponse> =>
+export const getGroupVerifications = (challengeId: number) =>
   fetchRequest<GetGroupVerificationsResponse>(ENDPOINTS.MEMBERS.CHALLENGE.GROUP.VERIFICATIONS(challengeId))

--- a/src/features/challenge/api/participate/verification/group-verification.ts
+++ b/src/features/challenge/api/participate/verification/group-verification.ts
@@ -1,15 +1,15 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
 export type PostGroupVerificationBody = {
   imageUrl: string
   content: string | undefined
 }
 
-export type PostGroupVerificationResponse = ApiResponse<{
+export type PostGroupVerificationResponse = {
   verificationId: number
   createdAt: string
-}>
+}
 
 type PostGroupVerificationVariables = {
   challengeId: number
@@ -20,11 +20,11 @@ type PostGroupVerificationVariables = {
 export const PostGroupVerification = ({ challengeId, body }: PostGroupVerificationVariables) =>
   fetchRequest<PostGroupVerificationResponse>(ENDPOINTS.CHALLENGE.GROUP.VERIFY(challengeId), { body })
 
-export type GetGroupVerificationResultResponse = ApiResponse<{
+export type GetGroupVerificationResultResponse = {
   verificationId: number
   status: 'PENDING' | 'APPROVED' | 'REJECTED'
-}>
+}
 
 /** 인증 결과 조회 (롱폴링) */
-export const getGroupVerificationResult = (challengeId: number): Promise<GetGroupVerificationResultResponse> =>
+export const getGroupVerificationResult = (challengeId: number) =>
   fetchRequest<GetGroupVerificationResultResponse>(ENDPOINTS.CHALLENGE.GROUP.VERIFICATION_RESULT(challengeId))

--- a/src/features/challenge/api/verify-personal-challenge.ts
+++ b/src/features/challenge/api/verify-personal-challenge.ts
@@ -1,10 +1,10 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 import { ISOFormatString } from '@shared/types/date'
 
-export type VerifyGroupChallengeResponseType = ApiResponse<{
+export type VerifyGroupChallengeResponseType = {
   submittedAt: ISOFormatString
-}>
+}
 
 export type VerifyPersonalChallengeBody = {
   imageUrl: string

--- a/src/features/challenge/components/challenge/group/list/ChallengeListPage.tsx
+++ b/src/features/challenge/components/challenge/group/list/ChallengeListPage.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { Spinner } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 
+import { GroupChallengeItem } from '@features/challenge/api/get-group-challenge-list'
 import GroupChallengeCard from '@features/challenge/components/challenge/group/list/GroupChallengeCard'
 import { useInfiniteGroupChallenges } from '@features/challenge/hook/useGroupChallengeList'
 import Chatbot from '@shared/components/chatbot/Chatbot'
@@ -12,17 +13,6 @@ import GridBox from '@shared/components/Wrapper/GridBox'
 import { URL } from '@shared/constants/route/route'
 import LucideIcon from '@shared/lib/ui/LucideIcon'
 import { theme } from '@shared/styles/theme'
-
-type GroupChallenge = {
-  id: number
-  title: string
-  thumbnailUrl: string
-  leafReward: number
-  startDate: string
-  endDate: string
-  remainingDay: number
-  currentParticipantCount: number
-}
 
 const ChallengeListPage = () => {
   const searchParams = useSearchParams()
@@ -80,7 +70,7 @@ const ChallengeListPage = () => {
   }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
   // API 데이터 뽑아오기
-  const groupChallenges: GroupChallenge[] = data?.pages.flatMap(p => p.data.groupChallenges) ?? []
+  const groupChallenges: GroupChallengeItem[] = data?.pages.flatMap(p => p.groupChallenges) ?? []
 
   if (isLoading) return <Spinner size='lg' style={{ marginTop: '100px' }} />
   if (error) return <Message>Error: {error.message}</Message>

--- a/src/features/challenge/components/challenge/participate/ChallengeParticipatePage.tsx
+++ b/src/features/challenge/components/challenge/participate/ChallengeParticipatePage.tsx
@@ -28,12 +28,14 @@ export default function ChallengeParticipatePage() {
   const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteGroupParticipations(status)
 
-  const { data: CountObj } = useGroupParticipationsCount()
+  const { data: CountData } = useGroupParticipationsCount()
+
+  const CountObj = CountData?.data.count
 
   // API 오류 여부
   const hasError = Boolean(error)
 
-  const realChallenges = data?.pages.flatMap(p => p.data.challenges) ?? []
+  const realChallenges = data?.pages.flatMap(p => p.challenges) ?? []
   // const url = URL.CHALLENGE.PARTICIPATE.DETAILS
   const tabLabels = [
     `참여 전 (${CountObj?.notStarted ?? 0})`,

--- a/src/features/challenge/hook/useGroupChallengeList.ts
+++ b/src/features/challenge/hook/useGroupChallengeList.ts
@@ -6,6 +6,7 @@ import {
   type FetchGroupChallengesResponse,
 } from '@features/challenge/api/get-group-challenge-list'
 import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
+import { ApiResponse } from '@shared/lib/api/fetcher/fetcher'
 
 /**
  * 단체 챌린지 목록 조회를 위한 React Query 훅 (무한 스크롤)
@@ -15,7 +16,7 @@ import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
 export const useInfiniteGroupChallenges = (category: string, input: string) =>
   useInfiniteQuery<
     // 한 페이지당 반환되는 데이터 타입
-    FetchGroupChallengesResponse,
+    ApiResponse<FetchGroupChallengesResponse>,
     // 에러 타입
     Error,
     // 최종 Data 타입: FetchGroupChallengesResponse 그대로 사용

--- a/src/features/challenge/hook/useGroupParticipationsCount.ts
+++ b/src/features/challenge/hook/useGroupParticipationsCount.ts
@@ -13,11 +13,8 @@ export interface CountObj {
 }
 
 export const useGroupParticipationsCount = () =>
-  useQuery<CountObj, Error>({
-    queryKey: [...QUERY_KEYS.MEMBER.CHALLENGE.GROUP.PARTICIPATIONS, 'count'] as const,
-    queryFn: async () => {
-      const res = await fetchGroupParticipationsCount() // no status param
-      return res.data.count
-    },
-    ...QUERY_OPTIONS.MEMBER.CHALLENGE.GROUP.PARTICIPATIONS,
+  useQuery({
+    queryKey: QUERY_KEYS.MEMBER.CHALLENGE.GROUP.COUNT,
+    queryFn: fetchGroupParticipationsCount, // no status param
+    ...QUERY_OPTIONS.MEMBER.CHALLENGE.GROUP.COUNT,
   })

--- a/src/features/challenge/hook/useGroupVerification.ts
+++ b/src/features/challenge/hook/useGroupVerification.ts
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { MUTATION_KEYS } from '@shared/config/tanstack-query/mutation-keys'
 import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
 import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
+import { ApiResponse } from '@shared/lib/api/fetcher/fetcher'
 
 import {
   getGroupVerificationResult,
@@ -16,7 +17,7 @@ import {
 /** 인증 제출 뮤테이션 */
 export const usePostGroupVerification = (challengeId: number) => {
   const qc = useQueryClient()
-  return useMutation<PostGroupVerificationResponse, Error, PostGroupVerificationBody>({
+  return useMutation<ApiResponse<PostGroupVerificationResponse>, Error, PostGroupVerificationBody>({
     mutationKey: [MUTATION_KEYS.CHALLENGE.GROUP.VERIFY],
     mutationFn: body => PostGroupVerification({ challengeId, body }),
     onSuccess: () => {

--- a/src/features/challenge/hook/useGroupVerificationList.ts
+++ b/src/features/challenge/hook/useGroupVerificationList.ts
@@ -3,16 +3,13 @@ import { useQuery } from '@tanstack/react-query'
 import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
 import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
 
-import {
-  getGroupVerifications,
-  GetGroupVerificationsResponse,
-} from '../api/participate/verification/group-verification-list'
+import { getGroupVerifications } from '../api/participate/verification/group-verification-list'
 
 /**
  * 단체 챌린지 인증 내역 조회 훅
  */
 export const useGroupVerifications = (challengeId: number) =>
-  useQuery<GetGroupVerificationsResponse, Error>({
+  useQuery({
     queryKey: QUERY_KEYS.MEMBER.CHALLENGE.GROUP.VERIFICATIONS(challengeId),
     queryFn: () => getGroupVerifications(challengeId),
     ...QUERY_OPTIONS.MEMBER.CHALLENGE.GROUP.VERIFICATIONS,

--- a/src/features/challenge/hook/useInfiniteGroupParticipations.ts
+++ b/src/features/challenge/hook/useInfiniteGroupParticipations.ts
@@ -1,6 +1,7 @@
 import { type InfiniteData, useInfiniteQuery } from '@tanstack/react-query'
 
 import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
+import { ApiResponse } from '@shared/lib/api/fetcher/fetcher'
 
 import type { ChallengeResponse } from '../api/participate/group-participant'
 import {
@@ -11,7 +12,7 @@ import {
 
 export const useInfiniteGroupParticipations = (status: ChallengeStatus) =>
   useInfiniteQuery<
-    ChallengeResponse, // queryFn 반환 타입
+    ApiResponse<ChallengeResponse>, // queryFn 반환 타입
     Error, // 에러 타입
     InfiniteData<ChallengeResponse>, // data 타입
     readonly [...typeof QUERY_KEYS.MEMBER.CHALLENGE.GROUP.PARTICIPATIONS, ChallengeStatus]

--- a/src/features/chatbot/chatbot-base-info.ts
+++ b/src/features/chatbot/chatbot-base-info.ts
@@ -1,5 +1,5 @@
 import { HttpMethod } from '@shared/constants/http'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
 // 카테고리 기반 챌린지 추천 요청 엔드포인트
 export const CATEGORY_RECOMMENDATION_ENDPOINT = {
@@ -49,8 +49,6 @@ export interface RecommendationResponseDataDTO {
  * @throws 500 - 서버 내부 오류 ("서버 내부 오류로 추천에 실패했습니다.")
  * @throws 502 - AI 서버 연결 실패 ("AI 서버로부터 추천 결과를 받아오는 데 실패했습니다.")
  */
-export const requestCategoryBasedRecommendation = (
-  body: CategoryRecommendationRequestDTO,
-): Promise<ApiResponse<RecommendationResponseDataDTO>> => {
+export const requestCategoryBasedRecommendation = (body: CategoryRecommendationRequestDTO) => {
   return fetchRequest(CATEGORY_RECOMMENDATION_ENDPOINT, { body })
 }

--- a/src/features/chatbot/chatbot-free-text.ts
+++ b/src/features/chatbot/chatbot-free-text.ts
@@ -1,7 +1,5 @@
 import { HttpMethod } from '@shared/constants/http'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
-
-import { RecommendationResponseDataDTO } from './chatbot-base-info'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
 // 자유 텍스트 기반 챌린지 추천 요청 엔드포인트
 export const FREETEXT_RECOMMENDATION_ENDPOINT = {
@@ -31,9 +29,7 @@ export interface FreetextRecommendationRequestDTO {
  * @throws 500 - 서버 내부 오류 ("서버 내부 오류로 인해 챌린지 추천에 실패했습니다.")
  * @throws 502 - AI 서버 연결 실패 ("AI 서버로부터 추천 결과를 받아오는 데 실패했습니다.")
  */
-export const requestFreetextBasedRecommendation = (
-  body: FreetextRecommendationRequestDTO,
-): Promise<ApiResponse<RecommendationResponseDataDTO>> => {
+export const requestFreetextBasedRecommendation = (body: FreetextRecommendationRequestDTO) => {
   // message가 5글자 이상인지 로컬에서 검증 (선택적)
   if (body.message && body.message.length < 5) {
     return Promise.reject({

--- a/src/features/member/api/get-alarm.ts
+++ b/src/features/member/api/get-alarm.ts
@@ -1,6 +1,6 @@
 import { ChallengeType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 import { ISOFormatString } from '@shared/types/date'
 
 export interface MemberAlarmListParams {
@@ -28,12 +28,9 @@ export type MemberAlarmList = {
   }
 }
 
-type GetMemberAlarmListResponse = ApiResponse<MemberAlarmList>
+type GetMemberAlarmListResponse = MemberAlarmList
 
-export const getMemberAlarmList = ({
-  cursorId,
-  cursorTimestamp,
-}: MemberAlarmListParams): Promise<GetMemberAlarmListResponse> => {
+export const getMemberAlarmList = ({ cursorId, cursorTimestamp }: MemberAlarmListParams) => {
   return fetchRequest<GetMemberAlarmListResponse>(ENDPOINTS.MEMBERS.NOTIFICATION.LIST, {
     query: {
       ...(cursorId !== undefined ? { cursorId } : {}),

--- a/src/features/member/api/get-alarm.ts
+++ b/src/features/member/api/get-alarm.ts
@@ -1,6 +1,7 @@
 import { ChallengeType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { InfiniteScrollResponse } from '@shared/types/api'
 import { ISOFormatString } from '@shared/types/date'
 
 export interface MemberAlarmListParams {
@@ -19,14 +20,9 @@ export type AlarmType = {
   challengeId: number
 }
 
-export type MemberAlarmList = {
+export type MemberAlarmList = InfiniteScrollResponse<{
   notifications: AlarmType[]
-  hasNext: boolean
-  cursorInfo: {
-    lastCursorId: number
-    cursorTimestamp: ISOFormatString
-  }
-}
+}>
 
 type GetMemberAlarmListResponse = MemberAlarmList
 

--- a/src/features/member/api/logout.ts
+++ b/src/features/member/api/logout.ts
@@ -1,13 +1,13 @@
 import { LowercaseOAuthType } from '@entities/member/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
-export type LogoutResponse = ApiResponse<null>
+export type LogoutResponse = null
 
 export type LogoutVariables = {
   provider: LowercaseOAuthType
 }
 
-export const Logout = ({ provider }: LogoutVariables): Promise<LogoutResponse> => {
+export const Logout = ({ provider }: LogoutVariables) => {
   return fetchRequest<LogoutResponse>(ENDPOINTS.MEMBERS.AUTH.LOGOUT(provider))
 }

--- a/src/features/member/api/nickname-duplicate.ts
+++ b/src/features/member/api/nickname-duplicate.ts
@@ -1,13 +1,13 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
 // TODO : isDuplicated -> isAvailable 로 변수명 저정
 /**
  * false: 사용 가능 / true 사용 불가능
  */
-type NicknameDuplicateResponseType = ApiResponse<{
+type NicknameDuplicateResponse = {
   isDuplicated: boolean
-}>
+}
 
 type NicknameDuplicateQuery = {
   input: string
@@ -17,7 +17,7 @@ type NicknameDuplicateQuery = {
  * 닉네임 중복 검사 API
  */
 export const NicknameDuplicate = (query: NicknameDuplicateQuery) => {
-  return fetchRequest<NicknameDuplicateResponseType>(ENDPOINTS.MEMBERS.DUPLICATE_NICKNAME, {
+  return fetchRequest<NicknameDuplicateResponse>(ENDPOINTS.MEMBERS.DUPLICATE_NICKNAME, {
     query,
   })
 }

--- a/src/features/member/api/oauth-callback.ts
+++ b/src/features/member/api/oauth-callback.ts
@@ -1,23 +1,20 @@
 import { LowercaseOAuthType } from '@entities/member/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
-type LoginCallbackResponseType = ApiResponse<{
+type LoginCallbackResponse = {
   isMember: boolean
   email: string
   nickname: string
   imageUrl: string
-}>
+}
 
 type LoginCallbackQuery = {
   code: string
 }
 
-export const LoginCallback = (
-  provider: LowercaseOAuthType,
-  query: LoginCallbackQuery,
-): Promise<LoginCallbackResponseType> => {
-  return fetchRequest<LoginCallbackResponseType>(ENDPOINTS.MEMBERS.AUTH.CALLBACK(provider), {
+export const LoginCallback = (provider: LowercaseOAuthType, query: LoginCallbackQuery) => {
+  return fetchRequest<LoginCallbackResponse>(ENDPOINTS.MEMBERS.AUTH.CALLBACK(provider), {
     query,
   })
 }

--- a/src/features/member/api/oauth-login.ts
+++ b/src/features/member/api/oauth-login.ts
@@ -1,11 +1,11 @@
 import { LowercaseOAuthType } from '@entities/member/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
-type LoginResponseType = ApiResponse<{
+type LoginResponse = {
   redirectUrl: string
-}>
+}
 
 export const Login = (provider: LowercaseOAuthType) => {
-  return fetchRequest<LoginResponseType>(ENDPOINTS.MEMBERS.AUTH.LOGIN(provider))
+  return fetchRequest<LoginResponse>(ENDPOINTS.MEMBERS.AUTH.LOGIN(provider))
 }

--- a/src/features/member/api/read-all-alarms.ts
+++ b/src/features/member/api/read-all-alarms.ts
@@ -1,8 +1,8 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
-export type ReadAllAlarmsResponse = ApiResponse<null>
+export type ReadAllAlarmsResponse = null
 
-export const readAllAlarms = (): Promise<ReadAllAlarmsResponse> => {
+export const readAllAlarms = () => {
   return fetchRequest<ReadAllAlarmsResponse>(ENDPOINTS.MEMBERS.NOTIFICATION.READ)
 }

--- a/src/features/member/api/signup.ts
+++ b/src/features/member/api/signup.ts
@@ -1,14 +1,11 @@
 import { OAuthType } from '@entities/member/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
-/**
- * false: 사용 가능 / true 사용 불가능
- */
-export type SignUpResponseType = ApiResponse<{
+export type SignUpResponse = {
   nickname: string
   imageUrl: string
-}>
+}
 
 export type SignUpBody = {
   email: string
@@ -28,7 +25,7 @@ export type SignUpVariables = {
  * 회원가입
  */
 export const SignUp = ({ body }: SignUpVariables) => {
-  return fetchRequest<SignUpResponseType>(ENDPOINTS.MEMBERS.SIGNUP, {
+  return fetchRequest<SignUpResponse>(ENDPOINTS.MEMBERS.SIGNUP, {
     body,
   })
 }

--- a/src/features/member/api/unregister.ts
+++ b/src/features/member/api/unregister.ts
@@ -1,7 +1,7 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
-export type UnregisterResponse = ApiResponse<null>
+export type UnregisterResponse = null
 
 /** 회원탈퇴, 토큰으로 유저 정보 판단 (인자 없음) */
 export const Unregister = () => {

--- a/src/shared/config/tanstack-query/mutation-defaults.ts
+++ b/src/shared/config/tanstack-query/mutation-defaults.ts
@@ -181,5 +181,5 @@ queryClient.setMutationDefaults(MUTATION_KEYS.MEMBER.NOTIFICATION.READ, {
  */
 
 export const useMutationStore = <TData, TVariables>(mutationKey: readonly unknown[]) => {
-  return useMutation<TData, ErrorResponse, TVariables, unknown>({ mutationKey })
+  return useMutation<ApiResponse<TData>, ErrorResponse, TVariables, unknown>({ mutationKey })
 }

--- a/src/shared/hooks/useImageUpload/useImageUpload.ts
+++ b/src/shared/hooks/useImageUpload/useImageUpload.ts
@@ -2,12 +2,12 @@ import { useCallback, useState } from 'react'
 
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { HttpMethod } from '@shared/constants/http'
-import { ApiResponse, fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 
-type signedUrlResponse = ApiResponse<{
+type PresignedUrlResponse = {
   uploadUrl: string // GCS로 PUT 요청을 보낼 PreSigned URL
   fileUrl: string // 버킷 내부에 저장될 객체 경로 (key)
-}>
+}
 
 export function useImageUpload() {
   const [loading, setLoading] = useState(false)
@@ -20,7 +20,7 @@ export function useImageUpload() {
     const uniqueName = `${Date.now()}-${uniqueId}-${file.name}`
 
     try {
-      const signed = await fetchRequest<signedUrlResponse>(ENDPOINTS.S3.PRESIGNED_URL, {
+      const signed = await fetchRequest<PresignedUrlResponse>(ENDPOINTS.S3.PRESIGNED_URL, {
         body: {
           fileName: uniqueName,
           contentType: file.type,

--- a/src/shared/lib/api/fetcher/fetcher.ts
+++ b/src/shared/lib/api/fetcher/fetcher.ts
@@ -55,7 +55,11 @@ async function refreshAccessToken(): Promise<void> {
   return refreshPromise
 }
 
-export async function fetchRequest<T>(endpoint: EndpointType, options: OptionsType = {}, isRetry = false): Promise<T> {
+export async function fetchRequest<T>(
+  endpoint: EndpointType,
+  options: OptionsType = {},
+  isRetry = false,
+): Promise<ApiResponse<T>> {
   /** Request */
   const { method, path } = endpoint
 
@@ -113,7 +117,7 @@ export async function fetchRequest<T>(endpoint: EndpointType, options: OptionsTy
     throw error
   }
 
-  return data as T
+  return data as ApiResponse<T>
 }
 
 /** 사용 예시

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -1,0 +1,13 @@
+import { ISOFormatString } from './date'
+
+export type CursorInfoType = {
+  lastCursorId: number
+  cursorTimestamp: ISOFormatString
+}
+
+export type InfiniteScrollBase = {
+  hasNext: boolean
+  cursorInfo: CursorInfoType
+}
+
+export type InfiniteScrollResponse<T> = T & InfiniteScrollBase


### PR DESCRIPTION
# 🍀 무엇을 위한 PR인가요?


## 🌱 이슈 설명

현재, useMutationStore과 이를 사용하는 API 구조입니다.

### 1. useMutationStore

- TData를 제너릭 타입으로 입력받는데, 해당 타입은 (아래 설명 이어서)

```typescript
export const useMutationStore = <TData, TVariables>(mutationKey: readonly unknown[]) => {
  return useMutation<TData, ErrorResponse, TVariables, unknown>({ mutationKey })
}

  /** 단체 챌린지 생성 */
  const { mutate: CreateChallengeMutate, isPending: isCreating } = useMutationStore<
    CreateChallengeResponse,
    CreateChallengeVariables
  >(MUTATION_KEYS.CHALLENGE.GROUP.CREATE)
```


### 2. API 구현 코드

(이어서)
-  Response 타입을 ApiResponse로 감싸서 사용하고 있습니다. 

이렇게 유지해도 괜찮지만, 모든 API 코드에서 `ApiResponse`로 감싸줘야 하므로, fetcher 내부에서 해당 로직을 처리하도록 구현하면 보일러 플레이트가 적어지도록 하였습니다.

```typescript
export type CreateChallengeResponse = ApiResponse<{
  id: number
}>

export type CreateChallengeVariables = {
  body: CreateChallengeBody
}

/**
 * 닉네임 중복 검사 API
 */
export const CreateChallenge = ({ body }: CreateChallengeVariables) => {
  return fetchRequest<CreateChallengeResponse>(ENDPOINTS.CHALLENGE.GROUP.CREATE, {
    body,
  })
}
```

## 변경된 최종 코드

### 1. fetchRequest에 제너릭 타입 추가

```typescript
export async function fetchRequest<T>(
  endpoint: EndpointType,
  options: OptionsType = {},
  isRetry = false,
): Promise<ApiResponse<T>> {
```


### 2. Tanstack Query의 useMutationStore에 제너릭 타입 추가
기존에는 반환타입을 ApiResponse으로 묶었지만, 이를 해제하였으므로, useMutationStore 에서 묶어주도록 변경하였습니다.

```typescript
export const useMutationStore = <TData, TVariables>(mutationKey: readonly unknown[]) => {
  return useMutation<ApiResponse<TData>, ErrorResponse, TVariables, unknown>({ mutationKey })
}
```

## 2. 무한스크롤 공통 타입 분리

무한스크롤 응답에는 hasNext, cursorInfo가 겹치는 것을 확인하여 이를 타입으로 분리한 뒤 리펙토링 진행하였습니다.
- 반복되는 코드는 최소화합시다!

```typescript
import { ISOFormatString } from './date'

export type CursorInfoType = {
  lastCursorId: number
  cursorTimestamp: ISOFormatString
}

export type InfiniteScrollBase = {
  hasNext: boolean
  cursorInfo: CursorInfoType
}

export type InfiniteScrollResponse<T> = T & InfiniteScrollBase
```

### 예시 변경 파일

이전
```typescript
export interface ChallengeResponse {
  challenges: Array<{
    id: number
    title: string
    thumbnailUrl: string
    startDate: string
    endDate: string
    achievement: {
      success: number
      total: number
    }
  }>
  hasNext: boolean
  cursorInfo: {
    lastCursorId: number
    cursorTimestamp: string
  }
}
```

이후
```typescript
export type ChallengeResponse = InfiniteScrollResponse<{
  challenges: {
    id: number
    title: string
    thumbnailUrl: string
    startDate: string
    endDate: string
    achievement: {
      success: number
      total: number
    }
  }[]
}>

```

## 관련 이슈

Relates #109 
Closes #96 


### PR간 오류 혹은 질문은 댓글로 남겨주세요!
