### PR TITLE
FE: PR(feat) 단체 챌린지 수정 페이지 구현

### DIFF
--- a/src/app/(with-header)/challenge/group/[id]/modify/page.tsx
+++ b/src/app/(with-header)/challenge/group/[id]/modify/page.tsx
@@ -1,0 +1,42 @@
+import { notFound } from 'next/navigation'
+
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
+
+import { getGroupChallengeDetails } from '@features/challenge/api/get-group-challenge-details'
+import ChallengeGroupModifyPage from '@features/challenge/components/challenge/group/modify/ChallengeGroupModifyPage'
+import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
+import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
+import { getQueryClient } from '@shared/config/tanstack-query/queryClient'
+
+interface GroupChallengeModifyPageProps {
+  params: Promise<{ id: string }>
+}
+
+const GroupChallengeModifyPage = async ({ params }: GroupChallengeModifyPageProps) => {
+  const { id } = await params
+  const challengeId = Number(id)
+  if (isNaN(challengeId)) return notFound()
+
+  const queryClient = getQueryClient()
+
+  try {
+    await queryClient.prefetchQuery({
+      queryKey: QUERY_KEYS.CHALLENGE.GROUP.DETAILS(challengeId),
+      queryFn: () => getGroupChallengeDetails(challengeId),
+      ...QUERY_OPTIONS.CHALLENGE.GROUP.DETAILS,
+    })
+
+    const dehydratedState = dehydrate(queryClient)
+
+    return (
+      <HydrationBoundary state={dehydratedState}>
+        <ChallengeGroupModifyPage challengeId={challengeId} />
+      </HydrationBoundary>
+    )
+  } catch (err) {
+    console.error('[SSR] 단체 챌린지 상세 프리패치 실패:', err)
+    return <div>단체 챌린지 상세 정보를 불러오는 데 실패했습니다.</div>
+  }
+}
+
+export default GroupChallengeModifyPage

--- a/src/app/(with-header)/challenge/group/create/page.tsx
+++ b/src/app/(with-header)/challenge/group/create/page.tsx
@@ -1,12 +1,38 @@
 import { Suspense } from 'react'
 
-import GroupChallengeCreatePage from '@features/challenge/components/challenge/group/create/GroupChallengeCreatePage'
+import { DetailFormValues } from '@features/challenge/components/challenge/group/create/DetailStep'
+import GroupChallengeCreatePage, {
+  FullFormValues,
+} from '@features/challenge/components/challenge/group/create/GroupChallengeCreatePage'
+import { MetaFormValues } from '@features/challenge/components/challenge/group/create/MetadataStep'
 import Loading from '@shared/components/loading'
 
 const Page = async () => {
+  const defaultMetaFormValues: MetaFormValues = {
+    title: '',
+    category: '',
+    startDate: new Date(),
+    endDate: new Date(new Date().getTime() + 24 * 60 * 60 * 1000),
+    startTime: '00:00',
+    endTime: '23:50',
+    maxParticipant: 0,
+    examples: [
+      { url: null, description: '', type: 'SUCCESS' },
+      { url: null, description: '', type: 'FAILURE' },
+    ],
+  }
+  const defaultDetailFormValues: DetailFormValues = {
+    description: '',
+    thumbnailUrl: '',
+  }
+
+  const defaultFormValues: FullFormValues = {
+    ...defaultMetaFormValues,
+    ...defaultDetailFormValues,
+  }
   return (
     <Suspense fallback={<Loading />}>
-      <GroupChallengeCreatePage />
+      <GroupChallengeCreatePage defaultValues={defaultFormValues} isEdit={false} />
     </Suspense>
   )
 }

--- a/src/app/(with-header)/challenge/group/create/page.tsx
+++ b/src/app/(with-header)/challenge/group/create/page.tsx
@@ -1,10 +1,10 @@
 import { Suspense } from 'react'
 
 import { DetailFormValues } from '@features/challenge/components/challenge/group/create/DetailStep'
-import GroupChallengeCreatePage, {
-  FullFormValues,
-} from '@features/challenge/components/challenge/group/create/GroupChallengeCreatePage'
 import { MetaFormValues } from '@features/challenge/components/challenge/group/create/MetadataStep'
+import GroupChallengeFormPage, {
+  FullFormValues,
+} from '@features/challenge/components/challenge/group/GroupChallengeFormPage'
 import Loading from '@shared/components/loading'
 
 const Page = async () => {
@@ -32,7 +32,7 @@ const Page = async () => {
   }
   return (
     <Suspense fallback={<Loading />}>
-      <GroupChallengeCreatePage defaultValues={defaultFormValues} isEdit={false} />
+      <GroupChallengeFormPage defaultValues={defaultFormValues} isEdit={false} />
     </Suspense>
   )
 }

--- a/src/app/(with-header)/member/signup/page.tsx
+++ b/src/app/(with-header)/member/signup/page.tsx
@@ -11,7 +11,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useOAuthUserStore } from '@entities/member/context/OAuthUserStore'
 import { OAuthType } from '@entities/member/type'
 import { NicknameDuplicate } from '@features/member/api/nickname-duplicate'
-import { SignUpBody, SignUpResponseType, SignUpVariables } from '@features/member/api/signup'
+import { SignUpBody, SignUpResponse, SignUpVariables } from '@features/member/api/signup'
 import { SignupFormType, signupSchema } from '@features/member/signup/schema'
 import ErrorText from '@shared/components/errortext'
 import { useMutationStore } from '@shared/config/tanstack-query/mutation-defaults'
@@ -51,7 +51,7 @@ const SignupPage = () => {
     ...QUERY_OPTIONS.MEMBER.DUPLICATE_NICKNAME,
   })
 
-  const { mutate: SignUpMutate } = useMutationStore<SignUpResponseType, SignUpVariables>(MUTATION_KEYS.MEMBER.SIGNUP)
+  const { mutate: SignUpMutate } = useMutationStore<SignUpResponse, SignUpVariables>(MUTATION_KEYS.MEMBER.SIGNUP)
 
   useEffect(() => {
     /** 이미 회원가입한 유저일 경우 */

--- a/src/features/challenge/api/create-group-challenge.ts
+++ b/src/features/challenge/api/create-group-challenge.ts
@@ -7,7 +7,7 @@ export type CreateChallengeResponse = {
   id: number
 }
 
-export type ExampleImageType = {
+export type ExampleImage = {
   imageUrl: string
   type: ChallengeVerificationResultType
   description: string
@@ -24,7 +24,7 @@ export type CreateChallengeBody = {
   endDate: DateFormatString
   verificationStartTime: TimeFormatString
   verificationEndTime: TimeFormatString
-  exampleImages: ExampleImageType[]
+  exampleImages: ExampleImage[]
 }
 
 export type CreateChallengeVariables = {

--- a/src/features/challenge/api/get-group-challenge-rules.ts
+++ b/src/features/challenge/api/get-group-challenge-rules.ts
@@ -3,7 +3,7 @@ import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 import { DateFormatString, TimeFormatString } from '@shared/types/date'
 
-type ExampleImageType = {
+type ExampleImage = {
   id: number
   imageUrl: string
   description: string
@@ -18,7 +18,7 @@ export type GroupChallengeRulesListResponse = {
     startTime: TimeFormatString
     endTime: TimeFormatString
   }
-  exampleImages: ExampleImageType[]
+  exampleImages: ExampleImage[]
 }
 
 export const getGroupChallengeRulesList = (challengeId: number) => {

--- a/src/features/challenge/api/modify-group-challenge.ts
+++ b/src/features/challenge/api/modify-group-challenge.ts
@@ -1,0 +1,46 @@
+import { ChallengeCategoryType, ChallengeVerificationResultType } from '@entities/challenge/type'
+import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
+import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
+import { DateFormatString, TimeFormatString } from '@shared/types/date'
+
+type KeepImage = {
+  id: number
+  sequenceNumber: number
+}
+type NewImage = {
+  imageUrl: string
+  type: ChallengeVerificationResultType
+  description: string
+  sequenceNumber: number
+}
+
+export type ModifyChallengeBody = {
+  title: string
+  description: string
+  category: ChallengeCategoryType // enum 값으로 관리
+  maxParticipantCount: number
+  thumbnailImageUrl: string
+  startDate: DateFormatString
+  endDate: DateFormatString
+  verificationStartTime: TimeFormatString
+  verificationEndTime: TimeFormatString
+  exampleImages: {
+    keep: KeepImage[]
+    new: NewImage[]
+    deleted: number[]
+  }
+}
+
+export type ModifyChallengeVariables = {
+  challengeId: number
+  body: ModifyChallengeBody
+}
+
+/**
+ * 단체 챌린지 수정 API
+ */
+export const ModifyChallenge = ({ challengeId, body }: ModifyChallengeVariables) => {
+  return fetchRequest<null>(ENDPOINTS.CHALLENGE.GROUP.MODIFY(challengeId), {
+    body,
+  })
+}

--- a/src/features/challenge/api/modify-group-challenge.ts
+++ b/src/features/challenge/api/modify-group-challenge.ts
@@ -3,11 +3,11 @@ import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 import { DateFormatString, TimeFormatString } from '@shared/types/date'
 
-type KeepImage = {
+export type KeepImage = {
   id: number
   sequenceNumber: number
 }
-type NewImage = {
+export type NewImage = {
   imageUrl: string
   type: ChallengeVerificationResultType
   description: string

--- a/src/features/challenge/api/verify-personal-challenge.ts
+++ b/src/features/challenge/api/verify-personal-challenge.ts
@@ -2,7 +2,7 @@ import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api/fetcher/fetcher'
 import { ISOFormatString } from '@shared/types/date'
 
-export type VerifyGroupChallengeResponseType = {
+export type VerifyGroupChallengeResponse = {
   submittedAt: ISOFormatString
 }
 
@@ -19,7 +19,7 @@ export type VerifyVariables = {
  * 개인 챌린지 인증 제출
  */
 export const VerifyGroupChallenge = ({ challengeId, body }: VerifyVariables) => {
-  return fetchRequest<VerifyGroupChallengeResponseType>(ENDPOINTS.CHALLENGE.PERSONAL.VERIFY(challengeId), {
+  return fetchRequest<VerifyGroupChallengeResponse>(ENDPOINTS.CHALLENGE.PERSONAL.VERIFY(challengeId), {
     body,
   })
 }

--- a/src/features/challenge/components/challenge/group/GroupChallengeFormPage.tsx
+++ b/src/features/challenge/components/challenge/group/GroupChallengeFormPage.tsx
@@ -27,6 +27,8 @@ import MetaDataStep, { metaSchema } from '@features/challenge/components/challen
 import { useMutationStore } from '@shared/config/tanstack-query/mutation-defaults'
 import { MUTATION_KEYS } from '@shared/config/tanstack-query/mutation-keys'
 import { URL } from '@shared/constants/route/route'
+import { ToastType } from '@shared/context/Toast/type'
+import { useToast } from '@shared/hooks/useToast/useToast'
 import { formatDateToDateFormatString } from '@shared/lib/date/utils'
 import { theme } from '@shared/styles/theme'
 import { TimeFormatString } from '@shared/types/date'
@@ -70,6 +72,7 @@ interface GroupChallengeFormPageProps {
 const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: GroupChallengeFormPageProps) => {
   const searchParams = useSearchParams()
   const router = useRouter()
+  const openToast = useToast()
 
   const [step, setStep] = useState<1 | 2>(1)
 
@@ -149,9 +152,8 @@ const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: 
           const challengeId: number = response.data.id
           router.push(URL.CHALLENGE.GROUP.DETAILS.value(challengeId))
         },
-        onError: () => {
-          // TODO : 토스트 에러 처리
-          // openToast(ToastType.Error, '회원가입 중 오류가 발생했습니다.')
+        onError(error) {
+          openToast(ToastType.Error, error.message)
         },
       },
     )
@@ -229,13 +231,12 @@ const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: 
       { challengeId, body },
       {
         onSuccess: () => {
-          alert('수정 성공!')
-
-          // router.push(URL.CHALLENGE.GROUP.DETAILS.value(challengeId))
+          // 단체 챌린지 상세 페이지로 이동
+          openToast(ToastType.Success, '챌린지 수정 성공')
+          router.push(URL.CHALLENGE.GROUP.DETAILS.value(challengeId))
         },
-        onError: () => {
-          // TODO: 토스트 에러 처리
-          alert('수정 실패!')
+        onError(error) {
+          openToast(ToastType.Error, error.message)
         },
       },
     )

--- a/src/features/challenge/components/challenge/group/GroupChallengeFormPage.tsx
+++ b/src/features/challenge/components/challenge/group/GroupChallengeFormPage.tsx
@@ -92,8 +92,6 @@ const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: 
     mode: 'onChange',
   })
 
-  console.log('예시 이미지', form.getValues().examples)
-
   /** 단체 챌린지 생성 */
   const { mutate: CreateChallengeMutate, isPending: isCreating } = useMutationStore<
     CreateChallengeResponse,
@@ -108,8 +106,6 @@ const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: 
 
   /** 단체 챌린지 생성 */
   const handleCreateSubmit = () => {
-    console.log('❌ 단체 챌린지 수정 실행됨')
-
     const data = form.getValues()
 
     const {
@@ -162,8 +158,6 @@ const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: 
 
   /** 단체 챌린지 수정 */
   const handleModifySubmit = () => {
-    console.log('✅ 단체 챌린지 수정 실행됨')
-
     if (!challengeId) return
 
     const {
@@ -178,8 +172,6 @@ const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: 
       endTime,
       examples,
     } = form.getValues()
-
-    console.log('예시 이미지 : ', examples)
 
     const originalExamples = defaultValues.examples ?? [] // 초기 데이터
     const uploadedExamples = examples.filter(e => e.url !== null) // 입력용 삭제

--- a/src/features/challenge/components/challenge/group/GroupChallengeFormPage.tsx
+++ b/src/features/challenge/components/challenge/group/GroupChallengeFormPage.tsx
@@ -104,6 +104,7 @@ const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: 
     ModifyChallengeVariables
   >(MUTATION_KEYS.CHALLENGE.GROUP.MODIFY)
 
+  const isPending: boolean = isCreating || isModifying
   /** 단체 챌린지 생성 */
   const handleCreateSubmit = () => {
     const data = form.getValues()
@@ -247,13 +248,15 @@ const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: 
           onNext={() => {
             setStep(2)
           }}
+          isEdit={isEdit}
         />
       ) : (
         <DetailStep
           form={form}
           onBack={() => setStep(1)}
           onSubmit={!isEdit ? handleCreateSubmit : handleModifySubmit}
-          isCreating={isCreating}
+          isPending={isPending}
+          isEdit={isEdit}
         />
       )}
     </PageWrapper>

--- a/src/features/challenge/components/challenge/group/GroupChallengeFormPage.tsx
+++ b/src/features/challenge/components/challenge/group/GroupChallengeFormPage.tsx
@@ -55,13 +55,13 @@ const fullSchema = metaSchema
 
 export type FullFormValues = z.infer<typeof fullSchema>
 
-interface GroupChallengeCreatePageProps {
+interface GroupChallengeFormPageProps {
   defaultValues: FullFormValues
   isEdit?: boolean
   challengeId?: number
 }
 
-const GroupChallengeCreatePage = ({ defaultValues, isEdit = false, challengeId }: GroupChallengeCreatePageProps) => {
+const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: GroupChallengeFormPageProps) => {
   const searchParams = useSearchParams()
   const router = useRouter()
 
@@ -159,7 +159,7 @@ const GroupChallengeCreatePage = ({ defaultValues, isEdit = false, challengeId }
   )
 }
 
-export default GroupChallengeCreatePage
+export default GroupChallengeFormPage
 
 const PageWrapper = styled.div`
   width: 100%;

--- a/src/features/challenge/components/challenge/group/create/DetailStep.tsx
+++ b/src/features/challenge/components/challenge/group/create/DetailStep.tsx
@@ -12,7 +12,7 @@ import Loading from '@shared/components/loading'
 import LucideIcon from '@shared/lib/ui/LucideIcon'
 import { theme } from '@shared/styles/theme'
 
-import { FullFormValues } from './GroupChallengeCreatePage'
+import { FullFormValues } from '../GroupChallengeFormPage'
 
 export const detailSchema = z.object({
   description: z.string().min(1, '챌린지 설명을 입력해주세요'),

--- a/src/features/challenge/components/challenge/group/create/DetailStep.tsx
+++ b/src/features/challenge/components/challenge/group/create/DetailStep.tsx
@@ -25,7 +25,9 @@ interface DetailsStepProps {
   form: UseFormReturn<FullFormValues>
   onBack: () => void
   onSubmit: () => void
-  isCreating: boolean
+  isPending: boolean
+
+  isEdit: boolean
 }
 
 type WarningType = {
@@ -56,7 +58,7 @@ const CHALLENGE_DETAILS_WARNINGS: WarningType[] = [
   },
 ]
 
-const DetailStep = ({ form, onBack, onSubmit, isCreating }: DetailsStepProps) => {
+const DetailStep = ({ form, onBack, onSubmit, isPending, isEdit }: DetailsStepProps) => {
   const {
     register,
     setValue,
@@ -77,13 +79,17 @@ const DetailStep = ({ form, onBack, onSubmit, isCreating }: DetailsStepProps) =>
       onSubmit()
     }
   }
+
+  // 상수
+  const FORM_TITLE: string = isEdit ? '단체 챌린지 수정하기' : '단체 챌린지 만들기'
+  const BUTTON_TEXT = isEdit ? '수정하기' : '생성하기'
   return (
     <Container onSubmit={handleSubmit(handleDetailSubmit)}>
       <DividerWrapper>
         <ButtonWrapper onClick={onBack}>
           <BackButton name='ChevronLeft' size={24} />
         </ButtonWrapper>
-        <Text>단체 챌린지 만들기</Text>
+        <Text>{FORM_TITLE}</Text>
       </DividerWrapper>
       <FieldGroup>
         <FieldWrapper>
@@ -132,7 +138,7 @@ const DetailStep = ({ form, onBack, onSubmit, isCreating }: DetailsStepProps) =>
       </FieldGroup>
 
       <SubmitButton type='submit' disabled={!isValid} $active={isValid}>
-        {!isCreating ? '생성하기' : <Loading />}
+        {!isPending ? BUTTON_TEXT : <Loading />}
       </SubmitButton>
     </Container>
   )

--- a/src/features/challenge/components/challenge/group/create/DetailStep.tsx
+++ b/src/features/challenge/components/challenge/group/create/DetailStep.tsx
@@ -19,12 +19,7 @@ export const detailSchema = z.object({
   thumbnailUrl: z.string().min(1, '썸네일 이미지를 등록해주세요'),
 })
 
-type DetailFormValues = z.infer<typeof detailSchema>
-
-export const defaultDetailFormValues: DetailFormValues = {
-  description: '',
-  thumbnailUrl: '',
-}
+export type DetailFormValues = z.infer<typeof detailSchema>
 
 interface DetailsStepProps {
   form: UseFormReturn<FullFormValues>

--- a/src/features/challenge/components/challenge/group/create/GroupChallengeCreatePage.tsx
+++ b/src/features/challenge/components/challenge/group/create/GroupChallengeCreatePage.tsx
@@ -16,14 +16,8 @@ import {
   CreateChallengeVariables,
   ExampleImageType,
 } from '@features/challenge/api/create-group-challenge'
-import DetailStep, {
-  defaultDetailFormValues,
-  detailSchema,
-} from '@features/challenge/components/challenge/group/create/DetailStep'
-import MetaDataStep, {
-  defaultMetaFormValues,
-  metaSchema,
-} from '@features/challenge/components/challenge/group/create/MetadataStep'
+import DetailStep, { detailSchema } from '@features/challenge/components/challenge/group/create/DetailStep'
+import MetaDataStep, { metaSchema } from '@features/challenge/components/challenge/group/create/MetadataStep'
 import { useMutationStore } from '@shared/config/tanstack-query/mutation-defaults'
 import { MUTATION_KEYS } from '@shared/config/tanstack-query/mutation-keys'
 import { URL } from '@shared/constants/route/route'
@@ -61,27 +55,34 @@ const fullSchema = metaSchema
 
 export type FullFormValues = z.infer<typeof fullSchema>
 
-const GroupChallengeCreatePage = () => {
-  const [step, setStep] = useState<1 | 2>(1)
+interface GroupChallengeCreatePageProps {
+  defaultValues: FullFormValues
+  isEdit?: boolean
+  challengeId?: number
+}
+
+const GroupChallengeCreatePage = ({ defaultValues, isEdit = false, challengeId }: GroupChallengeCreatePageProps) => {
+  const searchParams = useSearchParams()
   const router = useRouter()
 
-  const searchParams = useSearchParams()
+  const [step, setStep] = useState<1 | 2>(1)
+
   const categoryFromQuery = searchParams.get('category') ?? ''
+  const categoryKor: string = convertLanguage(CHALLENGE_CATEGORY_PAIRS, 'eng', 'kor')(categoryFromQuery) ?? ''
 
-  const convertCategory = convertLanguage(CHALLENGE_CATEGORY_PAIRS, 'eng', 'kor')
-  const categoryKor = convertCategory(categoryFromQuery) ?? '' // '제로웨이스트'
-
-  const defaultValues = useMemo(() => {
-    return {
-      ...defaultMetaFormValues,
-      ...defaultDetailFormValues,
+  const mergedDefaultValues = useMemo(() => {
+    const createdDefaultValues: FullFormValues = {
+      ...defaultValues,
       category: categoryKor,
     }
-  }, [categoryFromQuery])
+    const modifyDefaultValues: FullFormValues = { ...defaultValues }
+
+    return !isEdit ? createdDefaultValues : modifyDefaultValues
+  }, [categoryFromQuery, defaultValues])
 
   const form = useForm<FullFormValues>({
     resolver: zodResolver(fullSchema),
-    defaultValues,
+    defaultValues: mergedDefaultValues,
     mode: 'onChange',
   })
 

--- a/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
+++ b/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
@@ -59,9 +59,10 @@ export type MetaFormValues = z.infer<typeof metaSchema>
 interface MetaDataStepProps {
   form: UseFormReturn<FullFormValues>
   onNext: () => void
+  isEdit: boolean
 }
 
-const MetaDataStep = ({ form, onNext }: MetaDataStepProps) => {
+const MetaDataStep = ({ form, onNext, isEdit }: MetaDataStepProps) => {
   const {
     register,
     control,
@@ -115,10 +116,12 @@ const MetaDataStep = ({ form, onNext }: MetaDataStepProps) => {
     }
   }
 
+  // 상수
+  const FORM_TITLE: string = isEdit ? '단체 챌린지 수정하기' : '단체 챌린지 만들기'
   return (
     <Form onSubmit={handleMetaSubmit}>
       <DividerWrapper>
-        <Text>단체 챌린지 만들기</Text>
+        <Text>{FORM_TITLE}</Text>
       </DividerWrapper>
 
       <FieldGroup>

--- a/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
+++ b/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
@@ -19,7 +19,7 @@ import LucideIcon from '@shared/lib/ui/LucideIcon'
 import { StyledGeneric } from '@shared/styles/emotion/utils'
 import { theme } from '@shared/styles/theme'
 
-import { FullFormValues } from './GroupChallengeCreatePage'
+import { FullFormValues } from '../GroupChallengeFormPage'
 
 const PARTICIPANT_OPTIONS = Array.from(
   { length: Math.floor((PARTICIPANT_RANGE.MAX - PARTICIPANT_RANGE.MIN) / PARTICIPANT_RANGE.RANGE) + 1 },

--- a/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
+++ b/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
@@ -54,20 +54,7 @@ export const metaSchema = z.object({
     ),
 })
 
-type MetaFormValues = z.infer<typeof metaSchema>
-export const defaultMetaFormValues: MetaFormValues = {
-  title: '',
-  category: '',
-  startDate: new Date(),
-  endDate: new Date(new Date().getTime() + 24 * 60 * 60 * 1000),
-  startTime: '00:00',
-  endTime: '23:50',
-  maxParticipant: 0,
-  examples: [
-    { url: null, description: '', type: 'SUCCESS' },
-    { url: null, description: '', type: 'FAILURE' },
-  ],
-}
+export type MetaFormValues = z.infer<typeof metaSchema>
 
 interface MetaDataStepProps {
   form: UseFormReturn<FullFormValues>
@@ -124,6 +111,8 @@ const MetaDataStep = ({ form, onNext }: MetaDataStepProps) => {
       setIsSubmitted(true)
     }
     if (isMetaValid) {
+      console.log('다음 스텝으로 넘어갑니다.')
+
       onNext()
     }
   }

--- a/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
+++ b/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
@@ -46,11 +46,10 @@ export const metaSchema = z.object({
       examples => {
         const validSlots = examples.filter(e => e.url !== null)
         const hasSuccess = validSlots.some(e => e.type === 'SUCCESS')
-        const hasFailure = validSlots.some(e => e.type === 'FAILURE')
-        return hasSuccess && hasFailure
+        return hasSuccess
       },
       {
-        message: '성공/실패 예시 이미지를 최소 1개씩 등록해주세요.',
+        message: '성공 예시 이미지를 최소 1개 등록해주세요.',
       },
     ),
 })

--- a/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
+++ b/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
@@ -36,6 +36,7 @@ export const metaSchema = z.object({
   examples: z
     .array(
       z.object({
+        id: z.number().optional(), // 상세 포함, 생성 미포함
         url: z.string().nullable(),
         description: z.string(),
         type: z.enum(['SUCCESS', 'FAILURE']),

--- a/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
+++ b/src/features/challenge/components/challenge/group/create/MetadataStep.tsx
@@ -112,8 +112,6 @@ const MetaDataStep = ({ form, onNext }: MetaDataStepProps) => {
       setIsSubmitted(true)
     }
     if (isMetaValid) {
-      console.log('다음 스텝으로 넘어갑니다.')
-
       onNext()
     }
   }

--- a/src/features/challenge/components/challenge/group/modify/ChallengeGroupModifyPage.tsx
+++ b/src/features/challenge/components/challenge/group/modify/ChallengeGroupModifyPage.tsx
@@ -3,9 +3,13 @@
 import { ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
+import { CHALLENGE_CATEGORY_PAIRS, convertLanguage } from '@entities/challenge/constant'
+import { ChallengeCategoryTypeKor } from '@entities/challenge/type'
 import { getGroupChallengeDetails } from '@features/challenge/api/get-group-challenge-details'
 import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
 import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
+
+import GroupChallengeCreatePage, { FullFormValues } from '../create/GroupChallengeCreatePage'
 
 interface ChallengeGroupModifyPageProps {
   challengeId: number
@@ -13,16 +17,56 @@ interface ChallengeGroupModifyPageProps {
 
 const ChallengeGroupModifyPage = ({ challengeId }: ChallengeGroupModifyPageProps): ReactNode => {
   /** 단체 챌린지 상세 가져오기 */
-  const { data, isLoading } = useQuery({
+  const { data: challengeData, isLoading } = useQuery({
     queryKey: QUERY_KEYS.CHALLENGE.GROUP.DETAILS(challengeId),
     queryFn: () => getGroupChallengeDetails(challengeId),
     ...QUERY_OPTIONS.CHALLENGE.GROUP.DETAILS,
   })
 
-  if (data) {
-    console.log(data)
+  let contents
+  if (challengeData) {
+    const {
+      id,
+      // isEvent, // 이벤트 챌린지 여부
+      category,
+      title,
+      description,
+      startDate,
+      endDate,
+      verificationStartTime,
+      verificationEndTime,
+      // leafReward, // 보상 개수
+      thumbnailUrl,
+      exampleImages,
+      // verificationImages, // 참여자 인증 사진
+      maxParticipantCount,
+      // currentParticipantCount, // 참여자수
+      // status, // 제출 여부
+    } = challengeData.data
+
+    console.log(challengeData.data)
+
+    const defaultValues: FullFormValues = {
+      title,
+      description,
+      category: convertLanguage(CHALLENGE_CATEGORY_PAIRS, 'eng', 'kor')(category) as ChallengeCategoryTypeKor,
+      maxParticipant: maxParticipantCount,
+      thumbnailUrl,
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
+      startTime: verificationStartTime,
+      endTime: verificationEndTime,
+      examples: exampleImages.map((image, index) => ({
+        url: image.imageUrl,
+        type: image.type,
+        description: image.description,
+        sequenceNumber: image.sequenceNumber ?? index + 1,
+      })),
+    }
+
+    contents = <GroupChallengeCreatePage defaultValues={defaultValues} isEdit={true} challengeId={id} />
   }
-  return <div>ChallengeGroupModifyPage</div>
+  return contents
 }
 
 export default ChallengeGroupModifyPage

--- a/src/features/challenge/components/challenge/group/modify/ChallengeGroupModifyPage.tsx
+++ b/src/features/challenge/components/challenge/group/modify/ChallengeGroupModifyPage.tsx
@@ -27,7 +27,6 @@ const ChallengeGroupModifyPage = ({ challengeId }: ChallengeGroupModifyPageProps
   if (challengeData) {
     const {
       id,
-      // isEvent, // 이벤트 챌린지 여부
       category,
       title,
       description,
@@ -35,16 +34,15 @@ const ChallengeGroupModifyPage = ({ challengeId }: ChallengeGroupModifyPageProps
       endDate,
       verificationStartTime,
       verificationEndTime,
-      // leafReward, // 보상 개수
       thumbnailUrl,
       exampleImages,
-      // verificationImages, // 참여자 인증 사진
       maxParticipantCount,
+      // isEvent, // 이벤트 챌린지 여부
+      // leafReward, // 보상 개수
+      // verificationImages, // 참여자 인증 사진
       // currentParticipantCount, // 참여자수
       // status, // 제출 여부
     } = challengeData.data
-
-    console.log(challengeData.data)
 
     const defaultValues: FullFormValues = {
       title,
@@ -56,11 +54,12 @@ const ChallengeGroupModifyPage = ({ challengeId }: ChallengeGroupModifyPageProps
       endDate: new Date(endDate),
       startTime: verificationStartTime,
       endTime: verificationEndTime,
-      examples: exampleImages.map((image, index) => ({
+      examples: exampleImages.map(image => ({
+        id: image.id,
         url: image.imageUrl,
-        type: image.type,
         description: image.description,
-        sequenceNumber: image.sequenceNumber ?? index + 1,
+        type: image.type,
+        // sequenceNumber: image.sequenceNumber,
       })),
     }
 

--- a/src/features/challenge/components/challenge/group/modify/ChallengeGroupModifyPage.tsx
+++ b/src/features/challenge/components/challenge/group/modify/ChallengeGroupModifyPage.tsx
@@ -9,7 +9,7 @@ import { getGroupChallengeDetails } from '@features/challenge/api/get-group-chal
 import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
 import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
 
-import GroupChallengeCreatePage, { FullFormValues } from '../create/GroupChallengeCreatePage'
+import GroupChallengeFormPage, { FullFormValues } from '../GroupChallengeFormPage'
 
 interface ChallengeGroupModifyPageProps {
   challengeId: number
@@ -64,7 +64,7 @@ const ChallengeGroupModifyPage = ({ challengeId }: ChallengeGroupModifyPageProps
       })),
     }
 
-    contents = <GroupChallengeCreatePage defaultValues={defaultValues} isEdit={true} challengeId={id} />
+    contents = <GroupChallengeFormPage defaultValues={defaultValues} isEdit={true} challengeId={id} />
   }
   return contents
 }

--- a/src/features/challenge/components/challenge/group/modify/ChallengeGroupModifyPage.tsx
+++ b/src/features/challenge/components/challenge/group/modify/ChallengeGroupModifyPage.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import { getGroupChallengeDetails } from '@features/challenge/api/get-group-challenge-details'
+import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
+import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
+
+interface ChallengeGroupModifyPageProps {
+  challengeId: number
+}
+
+const ChallengeGroupModifyPage = ({ challengeId }: ChallengeGroupModifyPageProps): ReactNode => {
+  /** 단체 챌린지 상세 가져오기 */
+  const { data, isLoading } = useQuery({
+    queryKey: QUERY_KEYS.CHALLENGE.GROUP.DETAILS(challengeId),
+    queryFn: () => getGroupChallengeDetails(challengeId),
+    ...QUERY_OPTIONS.CHALLENGE.GROUP.DETAILS,
+  })
+
+  if (data) {
+    console.log(data)
+  }
+  return <div>ChallengeGroupModifyPage</div>
+}
+
+export default ChallengeGroupModifyPage

--- a/src/features/challenge/components/challenge/personal/details/ChallengePersonalDetails.tsx
+++ b/src/features/challenge/components/challenge/personal/details/ChallengePersonalDetails.tsx
@@ -14,7 +14,7 @@ import {
   PersonalChallengeDetail,
 } from '@features/challenge/api/get-personal-challenge-details'
 import {
-  VerifyGroupChallengeResponseType,
+  VerifyGroupChallengeResponse,
   VerifyPersonalChallengeBody,
   VerifyVariables,
 } from '@features/challenge/api/verify-personal-challenge'
@@ -114,7 +114,7 @@ const ChallengePersonalDetails = ({ challengeId, className }: ChallengePersonalD
   })
 
   /** 개인 챌린지 인증 생성 (제출) */
-  const { mutate: VerifyMutate, isPending } = useMutationStore<VerifyGroupChallengeResponseType, VerifyVariables>(
+  const { mutate: VerifyMutate, isPending } = useMutationStore<VerifyGroupChallengeResponse, VerifyVariables>(
     MUTATION_KEYS.CHALLENGE.PERSONAL.VERIFY,
   )
 

--- a/src/features/challenge/components/common/ChallengeVerifyExamples.tsx
+++ b/src/features/challenge/components/common/ChallengeVerifyExamples.tsx
@@ -72,21 +72,29 @@ const ChallengeVerifyExamples = ({
     const target = visibleExamples[index]
     const targetIndex = examples.findIndex(e => e === target)
 
-    if (targetIndex === -1) return // 보호 코드
+    if (targetIndex === -1) return
 
     let newExamples = [...examples]
-    const currentCount = newExamples.filter(e => e.url !== null).length
 
-    newExamples[targetIndex] = {
-      ...(data.url === null ? {} : { id: newExamples[targetIndex].id }), // 삭제 시 id 제거
-      ...newExamples[targetIndex],
-      ...data,
-      type,
+    // 1. 이미지가 있었는데 삭제됨 (url: '...', data.url === null)
+    if (newExamples[targetIndex].url && data.url === null) {
+      newExamples.splice(targetIndex, 1)
+    } else {
+      // 2. 이미지 추가
+      newExamples[targetIndex] = {
+        ...(data.url === null
+          ? {} // 삭제된 경우: id 제거
+          : newExamples[targetIndex].id !== undefined
+            ? { id: newExamples[targetIndex].id } // id 유지
+            : {}), // 새로 추가된 경우: id 없음
+        ...newExamples[targetIndex],
+        ...data,
+        type,
+      }
     }
 
-    console.log('after: ', newExamples)
-
-    /** Case: 이미지가 추가된 경우 이미지 입력창을 추가 */
+    // 3. 이미지가 추가되면 dummy 하나 더 추가
+    const currentCount = newExamples.filter(e => e.url !== null).length
     if (data.url !== undefined && data.url !== null) {
       const hasEmptySlot = newExamples.some(e => !e.id && e.url === null && e.type === type)
       if (!hasEmptySlot && currentCount < maxCount) {
@@ -98,9 +106,7 @@ const ChallengeVerifyExamples = ({
       }
     }
 
-    console.log('after1: ', newExamples)
-
-    /** 이미지 입력창 1개만 두기 */
+    // 4. 입력창은 타입별 하나만
     for (const result_type of CHALLENGE_VERIFICATION_RESULT) {
       const emptyItems = newExamples.filter(e => !e.id && e.url === null && e.type === result_type)
       if (emptyItems.length > 1) {
@@ -109,17 +115,13 @@ const ChallengeVerifyExamples = ({
       }
     }
 
-    console.log('after2: ', newExamples)
-
-    /** 성공 이미지 > 실패 이미지 > 성공 입력창 > 실패 입력창 */
+    // 5. 정렬
     newExamples.sort((a, b) => {
       const aUploaded = a.url !== null
       const bUploaded = b.url !== null
       if (aUploaded !== bUploaded) return aUploaded ? -1 : 1
       return a.type === 'SUCCESS' ? -1 : 1
     })
-
-    console.log('after3: ', newExamples)
 
     onChange(newExamples)
   }

--- a/src/features/challenge/components/common/ChallengeVerifyExamples.tsx
+++ b/src/features/challenge/components/common/ChallengeVerifyExamples.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import styled from '@emotion/styled'
 
 import { CHALLENGE_VERIFICATION_RESULT } from '@entities/challenge/constant'
@@ -39,6 +40,25 @@ const ChallengeVerifyExamples = ({
   verificationInputClassName,
 }: ChallengeVerifyExamplesProps) => {
   const { open } = useImageZoomStore()
+
+  /** 데이터 페칭을 통해 받은 examples 에는 입력을 위한 데이터가 없을 수 있으므로 추가가 필요함 */
+  useEffect(() => {
+    if (readOnly) return
+
+    const nextExamples = [...examples]
+
+    for (const type of CHALLENGE_VERIFICATION_RESULT) {
+      const hasInputSlot = nextExamples.some(e => e.type === type && e.url === null)
+      if (!hasInputSlot) {
+        nextExamples.push({ url: null, description: '', type })
+      }
+    }
+
+    // 변경된 경우만 onChange 호출
+    if (nextExamples.length !== examples.length) {
+      onChange(nextExamples)
+    }
+  }, [])
 
   const updateExamples = (
     index: number,

--- a/src/features/challenge/components/common/VerificationImageInput.tsx
+++ b/src/features/challenge/components/common/VerificationImageInput.tsx
@@ -72,7 +72,7 @@ const VerificationImageInput = ({
           readOnly={readOnly}
         />
         {imageUrl && (
-          <ZoomButton onClick={onZoom}>
+          <ZoomButton type='button' onClick={onZoom}>
             <LucideIcon name='Scan' size={24} color='lfWhite' />
           </ZoomButton>
         )}

--- a/src/shared/components/Modal/camera-modal/CameraModal.tsx
+++ b/src/shared/components/Modal/camera-modal/CameraModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import styled from '@emotion/styled'
 
 import { ChallengeVerificationStatusType } from '@entities/challenge/type'
+import CheckIcon from '@shared/components/check-icon/CheckIcon'
 import { useCameraModalStore } from '@shared/context/modal/CameraModalStore'
 import { ToastType } from '@shared/context/Toast/type'
 import { useImageUpload } from '@shared/hooks/useImageUpload/useImageUpload'
@@ -91,13 +92,6 @@ const CameraModal = () => {
     }
   }, [isOpen, previewUrl, facingMode])
 
-  // facingMode 변경 시 카메라 재시작-> 같은 기능을 하는 useEffect가 충돌
-  // useEffect(() => {
-  //   if (isOpen && !previewUrl) {
-  //     startCamera()
-  //   }
-  // }, [facingMode])
-
   useEffect(() => {
     if (tab === 1 && challengeData) setShowGuide(true)
     else setShowGuide(false)
@@ -172,20 +166,33 @@ const CameraModal = () => {
 
   let content
   if (!previewUrl || (previewUrl && !hasDescription)) {
-    content = (
-      <ShootWrapper type='button'>
-        <ShootButtonWrapper onClick={capture}>
-          <LucideIcon name='Camera' size={50} />
-          <ShootText>촬영하기</ShootText>
-        </ShootButtonWrapper>
-        <CovertCameraButton
-          name='SwitchCamera'
-          size={40}
-          strokeWidth={2}
-          onClick={() => setFacingMode(prev => (prev === 'user' ? 'environment' : 'user'))}
-        />
-      </ShootWrapper>
-    )
+    // 촬영 후
+    if (previewUrl) {
+      content = (
+        <ShootWrapper type='button'>
+          <ShootButtonWrapper onClick={capture}>
+            <CheckIcon />
+          </ShootButtonWrapper>
+        </ShootWrapper>
+      )
+    }
+    // 촬영 전
+    else {
+      content = (
+        <ShootWrapper type='button'>
+          <ShootButtonWrapper onClick={capture}>
+            <LucideIcon name='Camera' size={50} />
+            <ShootText>촬영하기</ShootText>
+          </ShootButtonWrapper>
+          <CovertCameraButton
+            name='SwitchCamera'
+            size={40}
+            strokeWidth={2}
+            onClick={() => setFacingMode(prev => (prev === 'user' ? 'environment' : 'user'))}
+          />
+        </ShootWrapper>
+      )
+    }
   } else if (hasDescription) {
     let label
     switch (status) {
@@ -411,6 +418,7 @@ const CloseButton = styled(LucideIcon)`
 const ShootButtonWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 8px;
 `
 

--- a/src/shared/components/Modal/camera-modal/VerificationGuideModal.tsx
+++ b/src/shared/components/Modal/camera-modal/VerificationGuideModal.tsx
@@ -20,6 +20,7 @@ import Loading from '@shared/components/loading'
 import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
 import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
 import { ChallengeDataType } from '@shared/context/modal/CameraModalStore'
+import { ApiResponse } from '@shared/lib/api/fetcher/fetcher'
 import LucideIcon from '@shared/lib/ui/LucideIcon'
 import { theme } from '@shared/styles/theme'
 
@@ -50,9 +51,9 @@ const VerificationGuideModal = ({ isOpen, challengeData, onClose }: Verification
       break
   }
 
-  const { data, isLoading } = useQuery<ChallengeRulesListResponse>({
-    queryKey: queryKey,
-    queryFn: queryFn,
+  const { data, isLoading } = useQuery<ApiResponse<ChallengeRulesListResponse>>({
+    queryKey,
+    queryFn,
     ...queryDefaults,
   })
 
@@ -65,10 +66,10 @@ const VerificationGuideModal = ({ isOpen, challengeData, onClose }: Verification
 
     let periodText = ''
     if (type === 'GROUP') {
-      const groupPeriod = certificationPeriod as GroupChallengeRulesListResponse['data']['certificationPeriod']
+      const groupPeriod = certificationPeriod as GroupChallengeRulesListResponse['certificationPeriod']
       periodText = `${groupPeriod.startDate.slice(2)} ~ ${groupPeriod.endDate.slice(2)}`
     } else {
-      const personalPeriod = certificationPeriod as PersonalChallengeRulesListResponse['data']['certificationPeriod']
+      const personalPeriod = certificationPeriod as PersonalChallengeRulesListResponse['certificationPeriod']
       periodText = convertLanguage(DAY_PAIRS, 'eng', 'kor')(personalPeriod.dayOfWeek) as string
     }
 

--- a/src/shared/components/check-icon/CheckIcon.tsx
+++ b/src/shared/components/check-icon/CheckIcon.tsx
@@ -1,0 +1,35 @@
+import { motion } from 'motion/react'
+
+import styled from '@emotion/styled'
+
+import { theme } from '@shared/styles/theme'
+
+const CheckIcon = () => {
+  return (
+    <CheckSvg
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    >
+      <motion.path
+        d='M5 13l4 4L19 7'
+        initial={{ pathLength: 0 }}
+        animate={{ pathLength: 1 }}
+        transition={{ duration: 0.5, ease: 'easeInOut' }}
+      />
+    </CheckSvg>
+  )
+}
+
+const CheckSvg = styled.svg`
+  width: 50px;
+  height: 50px;
+
+  color: ${theme.colors.lfBlack.base};
+`
+
+export default CheckIcon

--- a/src/shared/config/tanstack-query/mutation-defaults.ts
+++ b/src/shared/config/tanstack-query/mutation-defaults.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query'
 
 import { CreateChallenge } from '@features/challenge/api/create-group-challenge'
 import { DeleteGroupChallenge } from '@features/challenge/api/delete-group-challenge'
+import { ModifyChallenge } from '@features/challenge/api/modify-group-challenge'
 import { PostGroupVerification } from '@features/challenge/api/participate/verification/group-verification'
 import { ParticipateGroupChallenge } from '@features/challenge/api/participate-group-challenge'
 import { VerifyGroupChallenge } from '@features/challenge/api/verify-personal-challenge'
@@ -49,13 +50,25 @@ queryClient.setMutationDefaults(MUTATION_KEYS.CHALLENGE.GROUP.CREATE, {
 })
 
 // 수정
-queryClient.setMutationDefaults(MUTATION_KEYS.CHALLENGE.GROUP.UPDATE, {
-  mutationFn: async variables => {
-    // TODO: 수정 API 연결
-    return {} as ApiResponse<unknown>
-  },
+queryClient.setMutationDefaults(MUTATION_KEYS.CHALLENGE.GROUP.MODIFY, {
+  mutationFn: ModifyChallenge,
   onSuccess(data, variables, context) {
-    // TODO: 무효화 로직
+    const { challengeId } = variables
+
+    // 모든 단체 첼린지 목록 조회 (검색 포함) 쿼리 무효화
+    queryClient.invalidateQueries({
+      predicate: query =>
+        Array.isArray(query.queryKey) && query.queryKey[0] === 'challenges' && query.queryKey[1] === 'group',
+    })
+
+    // 단체 챌린지 상세 조회
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.CHALLENGE.GROUP.DETAILS(challengeId) })
+
+    // 생성한 단체 챌린지 목록
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.MEMBER.CHALLENGE.GROUP.CREATIONS })
+
+    // 참여한 단체 챌린지 카운트 조회
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.MEMBER.CHALLENGE.GROUP.COUNT })
   },
 })
 

--- a/src/shared/config/tanstack-query/mutation-keys.ts
+++ b/src/shared/config/tanstack-query/mutation-keys.ts
@@ -7,7 +7,7 @@ const CHALLENGE_MUTATION_KEYS = {
   /** 단체 챌린지 */
   GROUP: {
     CREATE: ['challenges', 'group', 'create'] as const, // 생성
-    UPDATE: ['challenges', 'group', 'modify'] as const, // 수정
+    MODIFY: ['challenges', 'group', 'modify'] as const, // 수정
     DELETE: ['challenges', 'group', 'delete'] as const, // 삭제
     PARTICIPATE: ['challenges', 'group', 'participate'] as const, // 참여
     VERIFY: ['challenges', 'group', 'verify'] as const, // 인증 제출

--- a/src/shared/constants/endpoint/endpoint.ts
+++ b/src/shared/constants/endpoint/endpoint.ts
@@ -62,7 +62,7 @@ const CHALLENGE_ENDPOINTS = {
     // 생성
     CREATE: { method: HttpMethod.POST, path: '/api/challenges/group' },
     // 수정
-    UPDATE: (challengeId: number) => ({
+    MODIFY: (challengeId: number) => ({
       method: HttpMethod.PATCH,
       path: `/api/challenges/group/${challengeId}`,
     }),

--- a/src/shared/styles/GlobalStyle.tsx
+++ b/src/shared/styles/GlobalStyle.tsx
@@ -28,6 +28,8 @@ const GlobalStyle = () => {
 
         * {
           box-sizing: border-box;
+
+          line-height: 1.3;
         }
 
         html {


### PR DESCRIPTION
# 🍀 무엇을 위한 PR인가요?

단체 챌린지 수정 페이지 구현

## 관련 이슈

Relates to #98
Closes #101
Closes #122 


# 주요 변경사항

## 수정 로직

1. 단체 챌린지 상세 조회
2. 기존 "단체 챌린지 생성" 페이지를 재활용하여, 디폴트 값을 기존 데이터로 채우기
3. 하나의 컴포넌트에서 생성, 수정을 담당하므로, `props`에 따라 `Mutation` 선정

## 추가 반영 

- 챌린지 생성/수정 예시 이미지 조건 변경 #122 
- 썸네일 촬영 시 체크 애니메이션 추가

### PR간 오류 혹은 질문은 댓글로 남겨주세요!
