### PR TITLE
PR:[feat] 환경에 따른 동적 api url 할당

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,9 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  },
 }
 
 module.exports = nextConfig

--- a/src/shared/lib/api/client-fetcher/client-fetcher.ts
+++ b/src/shared/lib/api/client-fetcher/client-fetcher.ts
@@ -5,7 +5,7 @@ import { ApiResponse, ErrorResponse, OptionsType } from '../type'
 import { refreshClientAccessToken } from './client-reissue'
 
 //TODO: dev/prod 환경에 따라 서로 다른 도메인 설정
-const BASE_URL = 'https://leafresh.app'
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL
 
 export async function clientFetchRequest<T>(
   endpoint: EndpointType,

--- a/src/shared/lib/api/client-fetcher/client-reissue.ts
+++ b/src/shared/lib/api/client-fetcher/client-reissue.ts
@@ -5,7 +5,7 @@ let isRefreshing = false
 let refreshPromise: Promise<void> | null = null
 
 //TODO: dev/prod 환경에 따라 서로 다른 도메인 설정
-const BASE_URL = 'https://leafresh.app'
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL
 
 export async function refreshClientAccessToken(): Promise<void> {
   const openToast = useToastStore.getState().open

--- a/src/shared/lib/api/server-fetcher/server-fetcher.ts
+++ b/src/shared/lib/api/server-fetcher/server-fetcher.ts
@@ -7,7 +7,7 @@ import { EndpointType } from '@shared/constants/endpoint/endpoint'
 import { ApiResponse, ErrorResponse, OptionsType } from '../type'
 import { refreshServerAccessToken } from './server-reissue'
 
-const BASE_URL = 'https://leafresh.app'
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL
 
 export async function serverFetchRequest<T>(
   endpoint: EndpointType,

--- a/src/shared/lib/api/server-fetcher/server-reissue.ts
+++ b/src/shared/lib/api/server-fetcher/server-reissue.ts
@@ -7,8 +7,8 @@ import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 let isRefreshing = false
 let refreshPromise: Promise<void> | null = null
 
-//TODO: dev/prod 환경에 따라 서로 다른 도메인 설정
-const BASE_URL = 'https://leafresh.app'
+//환경에 따라 다른 Url
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL
 
 export async function refreshServerAccessToken(): Promise<void> {
   if (isRefreshing) return refreshPromise ?? Promise.resolve()


### PR DESCRIPTION
# 🍀 무엇을 위한 PR인가요?

- env 적용

## 관련 이슈

Relates to #208
Closes #208

# 주요 변경사항

## 1. env 파일을 환경마다 분리하였습니다.
- 해당 파일은 다른 방식으로 공유하겠습니다.
## 2. BASE_URL 수정
- 기존 'https://leafresh.app'으로 되어 있던 BASE_URL을 `process.env.NEXT_PUBLIC_API_URL`로 교체하였습니다.

### PR간 오류 혹은 질문은 댓글로 남겨주세요!
