### PR TITLE
FE: [feat] 소셜 로그인 리다이렉트 경로 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+certificates

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,28 @@
+{
+  "folder-color.pathColors": [
+    {
+      "folderPath": "leafresh-fe/src/entities/",
+      "badge": "🟡"
+    },
+    {
+      "folderPath": "leafresh-fe/src/widgets/",
+      "badge": "🔴"
+    },
+    {
+      "folderPath": "leafresh-fe/src/features/",
+      "badge": "🟠"
+    },
+    {
+      "folderPath": "leafresh-fe/src/shared/",
+      "badge": "✅"
+    },
+    {
+      "folderPath": "leafresh-fe/src/app/",
+      "badge": "🔥"
+    },
+    {
+      "folderPath": "leafresh-fe/tests/",
+      "badge": "🧪"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack --experimental-https",
+    "dev": "next dev -H local.dev-leafresh.app -p 3000 --turbopack --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/app/(with-layout)/(with-header)/member/[provider]/callback/CallbackPage.tsx
+++ b/src/app/(with-layout)/(with-header)/member/[provider]/callback/CallbackPage.tsx
@@ -2,15 +2,19 @@
 
 import { useRouter, useSearchParams } from 'next/navigation'
 
+import { useEffect } from 'react'
 import styled from '@emotion/styled'
 import { useQuery } from '@tanstack/react-query'
 
+import { useOAuthStateStore } from '@entities/member/context/OAuthStateStore'
 import { useOAuthUserStore } from '@entities/member/context/OAuthUserStore'
 import { LowercaseOAuthType } from '@entities/member/type'
 import { LoginCallback } from '@features/member/api/oauth-callback'
 import Loading from '@shared/components/loading'
 import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
 import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
+import { URL } from '@shared/constants/route/route'
+import { ToastType } from '@shared/context/toast/type'
 import { useToast } from '@shared/hooks/useToast/useToast'
 
 interface CallbackPageProps {
@@ -21,31 +25,41 @@ const CallbackPage = ({ provider }: CallbackPageProps) => {
   const router = useRouter()
   const searchParams = useSearchParams()
   const openToast = useToast()
+
   const { setOAuthUserInfo } = useOAuthUserStore()
+  const { state } = useOAuthStateStore()
 
   const code = searchParams.get('code')
-
   const { data, isLoading, isError } = useQuery({
     queryKey: QUERY_KEYS.MEMBER.AUTH.CALLBACK(provider),
-    queryFn: () => LoginCallback(provider, { code: code as string }),
+    queryFn: () => {
+      if (!code || !state) {
+        return
+      }
+      return LoginCallback({
+        provider,
+        code,
+        state,
+      })
+    },
     ...QUERY_OPTIONS.MEMBER.AUTH.CALLBACK,
     enabled: typeof code === 'string' && code.length > 0,
   })
 
-  // useEffect(() => {
-  //   if (!data) return
-  //   const { isMember, email, imageUrl, nickname } = data.data
+  useEffect(() => {
+    if (!data) return
+    const { isMember, email, imageUrl, nickname } = data.data
 
-  //   setOAuthUserInfo({ isMember, email, imageUrl, nickname, provider })
+    setOAuthUserInfo({ isMember, email, imageUrl, nickname, provider })
 
-  //   if (!isMember) {
-  //     router.replace(URL.MEMBER.SIGNUP.value)
-  //   } else {
-  //     /** ✅ 주의 : UserStore 정보를 받아오지 않는 이유는 AT+RT 받기를 성공했으면 언젠가는 데이터를 불러올 수 있기 때문이다! */
-  //     openToast(ToastType.Success, '로그인 성공')
-  //     router.replace(URL.MAIN.INDEX.value)
-  //   }
-  // }, [data])
+    if (!isMember) {
+      router.replace(URL.MEMBER.SIGNUP.value)
+    } else {
+      /** ✅ 주의 : UserStore 정보를 받아오지 않는 이유는 AT+RT 받기를 성공했으면 언젠가는 데이터를 불러올 수 있기 때문이다! */
+      openToast(ToastType.Success, '로그인 성공')
+      router.replace(URL.MAIN.INDEX.value)
+    }
+  }, [data])
 
   if (isLoading) {
     return (

--- a/src/app/(with-layout)/(with-header)/member/[provider]/callback/CallbackPage.tsx
+++ b/src/app/(with-layout)/(with-header)/member/[provider]/callback/CallbackPage.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+
+import styled from '@emotion/styled'
+import { useQuery } from '@tanstack/react-query'
+
+import { useOAuthUserStore } from '@entities/member/context/OAuthUserStore'
+import { LowercaseOAuthType } from '@entities/member/type'
+import { LoginCallback } from '@features/member/api/oauth-callback'
+import Loading from '@shared/components/loading'
+import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
+import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
+import { useToast } from '@shared/hooks/useToast/useToast'
+
+interface CallbackPageProps {
+  provider: LowercaseOAuthType
+}
+
+const CallbackPage = ({ provider }: CallbackPageProps) => {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const openToast = useToast()
+  const { setOAuthUserInfo } = useOAuthUserStore()
+
+  const code = searchParams.get('code')
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: QUERY_KEYS.MEMBER.AUTH.CALLBACK(provider),
+    queryFn: () => LoginCallback(provider, { code: code as string }),
+    ...QUERY_OPTIONS.MEMBER.AUTH.CALLBACK,
+    enabled: typeof code === 'string' && code.length > 0,
+  })
+
+  // useEffect(() => {
+  //   if (!data) return
+  //   const { isMember, email, imageUrl, nickname } = data.data
+
+  //   setOAuthUserInfo({ isMember, email, imageUrl, nickname, provider })
+
+  //   if (!isMember) {
+  //     router.replace(URL.MEMBER.SIGNUP.value)
+  //   } else {
+  //     /** ✅ 주의 : UserStore 정보를 받아오지 않는 이유는 AT+RT 받기를 성공했으면 언젠가는 데이터를 불러올 수 있기 때문이다! */
+  //     openToast(ToastType.Success, '로그인 성공')
+  //     router.replace(URL.MAIN.INDEX.value)
+  //   }
+  // }, [data])
+
+  if (isLoading) {
+    return (
+      <LoadingWrapper>
+        <Loading />
+      </LoadingWrapper>
+    )
+  }
+
+  if (isError) {
+    // openToast(ToastType.Error, `${provider} 로그인 실패\n재시도 해주세요`)
+
+    return <p>로그인 실패</p>
+  }
+
+  // 데이터 로드 후 라우팅될 것이므로 빈 상태 반환
+  return null
+}
+
+export default CallbackPage
+
+const LoadingWrapper = styled.div`
+  width: 100%;
+  height: 100dvh;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`

--- a/src/app/(with-layout)/(with-header)/member/[provider]/callback/page.tsx
+++ b/src/app/(with-layout)/(with-header)/member/[provider]/callback/page.tsx
@@ -34,7 +34,6 @@ const CallbackPage = ({ params }: { params: Promise<{ provider: LowercaseOAuthTy
 
   useEffect(() => {
     if (!data) return
-
     const { isMember, email, imageUrl, nickname } = data.data
 
     setOAuthUserInfo({ isMember, email, imageUrl, nickname, provider })
@@ -46,7 +45,7 @@ const CallbackPage = ({ params }: { params: Promise<{ provider: LowercaseOAuthTy
       openToast(ToastType.Success, '로그인 성공')
       router.replace(URL.MAIN.INDEX.value)
     }
-  }, [data, router, openToast, setOAuthUserInfo])
+  }, [data])
 
   if (isLoading) {
     return (

--- a/src/app/(with-layout)/(with-header)/member/[provider]/callback/page.tsx
+++ b/src/app/(with-layout)/(with-header)/member/[provider]/callback/page.tsx
@@ -1,77 +1,12 @@
-'use client'
-
-import { useRouter, useSearchParams } from 'next/navigation'
-
-import { use, useEffect } from 'react'
-import styled from '@emotion/styled'
-import { useQuery } from '@tanstack/react-query'
-
-import { useOAuthUserStore } from '@entities/member/context/OAuthUserStore'
 import { LowercaseOAuthType } from '@entities/member/type'
-import { LoginCallback } from '@features/member/api/oauth-callback'
-import Loading from '@shared/components/loading'
-import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
-import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
-import { URL } from '@shared/constants/route/route'
-import { ToastType } from '@shared/context/toast/type'
-import { useToast } from '@shared/hooks/useToast/useToast'
 
-const CallbackPage = ({ params }: { params: Promise<{ provider: LowercaseOAuthType }> }) => {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const { provider } = use(params)
-  const openToast = useToast()
-  const { setOAuthUserInfo } = useOAuthUserStore()
+import CallbackPage from './CallbackPage'
 
-  const code = searchParams.get('code')
-
-  const { data, isLoading, isError } = useQuery({
-    queryKey: QUERY_KEYS.MEMBER.AUTH.CALLBACK(provider),
-    queryFn: () => LoginCallback(provider, { code: code! }),
-    enabled: !!code,
-    ...QUERY_OPTIONS.MEMBER.AUTH.CALLBACK,
-  })
-
-  useEffect(() => {
-    if (!data) return
-    const { isMember, email, imageUrl, nickname } = data.data
-
-    setOAuthUserInfo({ isMember, email, imageUrl, nickname, provider })
-
-    if (!isMember) {
-      router.replace(URL.MEMBER.SIGNUP.value)
-    } else {
-      /** ✅ 주의 : UserStore 정보를 받아오지 않는 이유는 AT+RT 받기를 성공했으면 언젠가는 데이터를 불러올 수 있기 때문이다! */
-      openToast(ToastType.Success, '로그인 성공')
-      router.replace(URL.MAIN.INDEX.value)
-    }
-  }, [data])
-
-  if (isLoading) {
-    return (
-      <LoadingWrapper>
-        <Loading />
-      </LoadingWrapper>
-    )
-  }
-
-  if (isError) {
-    openToast(ToastType.Error, `${provider} 로그인 실패\n재시도 해주세요`)
-
-    return <p>로그인 실패</p>
-  }
-
-  // 데이터 로드 후 라우팅될 것이므로 빈 상태 반환
-  return null
+interface Props {
+  params: Promise<{ provider: LowercaseOAuthType }>
 }
 
-export default CallbackPage
-
-const LoadingWrapper = styled.div`
-  width: 100%;
-  height: 100dvh;
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`
+export default async function Page({ params }: Props) {
+  const { provider } = await params
+  return <CallbackPage provider={provider} />
+}

--- a/src/app/(with-layout)/(with-header)/member/login/page.tsx
+++ b/src/app/(with-layout)/(with-header)/member/login/page.tsx
@@ -38,7 +38,6 @@ const LoginPage = () => {
       const { data } = await StartLogin()
       if (data?.data) {
         const { redirectUrl } = data.data
-        // const redirectUrl = 'https://localhost:3000/oauth/kakao/callback'
 
         window.location.href = redirectUrl
       }

--- a/src/entities/member/context/OAuthStateStore.ts
+++ b/src/entities/member/context/OAuthStateStore.ts
@@ -1,0 +1,22 @@
+// src/entities/member/context/OAuthStateStore.ts
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface OAuthStateStore {
+  state: string | null
+  setState: (value: string) => void
+  clearState: () => void
+}
+
+export const useOAuthStateStore = create(
+  persist<OAuthStateStore>(
+    set => ({
+      state: null,
+      setState: (value: string) => set({ state: value }),
+      clearState: () => set({ state: null }),
+    }),
+    {
+      name: 'oauth-state', // ✅ localStorage 키
+    },
+  ),
+)

--- a/src/features/member/api/oauth-callback.ts
+++ b/src/features/member/api/oauth-callback.ts
@@ -9,11 +9,18 @@ type LoginCallbackResponse = {
   imageUrl: string
 }
 
-type LoginCallbackQuery = {
+type LoginCallbackVariables = {
+  provider: LowercaseOAuthType
   code: string
+  state: string
 }
 
-export const LoginCallback = (provider: LowercaseOAuthType, query: LoginCallbackQuery) => {
+export const LoginCallback = ({ provider, code, state }: LoginCallbackVariables) => {
+  const query = {
+    code,
+    state,
+  }
+
   return fetchRequest<LoginCallbackResponse>(ENDPOINTS.MEMBERS.AUTH.CALLBACK(provider), {
     query,
   })

--- a/src/features/member/api/oauth-login.ts
+++ b/src/features/member/api/oauth-login.ts
@@ -9,7 +9,7 @@ type LoginResponse = {
 export const Login = (provider: LowercaseOAuthType) => {
   return fetchRequest<LoginResponse>(ENDPOINTS.MEMBERS.AUTH.LOGIN(provider), {
     query: {
-      origin: encodeURIComponent(window.location.origin),
+      origin: window.location.origin,
     },
   })
 }

--- a/src/features/member/api/oauth-login.ts
+++ b/src/features/member/api/oauth-login.ts
@@ -4,12 +4,14 @@ import { fetchRequest } from '@shared/lib/api'
 
 type LoginResponse = {
   redirectUrl: string
+  state: string // origin을 백엔드 JWT로 암호화한 값
 }
 
 export const Login = (provider: LowercaseOAuthType) => {
+  const origin: string = window.location.origin
   return fetchRequest<LoginResponse>(ENDPOINTS.MEMBERS.AUTH.LOGIN(provider), {
     query: {
-      origin: window.location.origin,
+      origin,
     },
   })
 }

--- a/src/features/member/api/oauth-login.ts
+++ b/src/features/member/api/oauth-login.ts
@@ -7,5 +7,9 @@ type LoginResponse = {
 }
 
 export const Login = (provider: LowercaseOAuthType) => {
-  return fetchRequest<LoginResponse>(ENDPOINTS.MEMBERS.AUTH.LOGIN(provider))
+  return fetchRequest<LoginResponse>(ENDPOINTS.MEMBERS.AUTH.LOGIN(provider), {
+    query: {
+      origin: encodeURIComponent(window.location.origin),
+    },
+  })
 }

--- a/src/shared/constants/endpoint/endpoint.ts
+++ b/src/shared/constants/endpoint/endpoint.ts
@@ -5,7 +5,6 @@ import { HttpMethod } from '../http'
 export type EndpointType = {
   method: HttpMethod
   path: string
-  credentials?: boolean
 }
 
 const CHALLENGE_ENDPOINTS = {
@@ -21,7 +20,6 @@ const CHALLENGE_ENDPOINTS = {
     DETAILS: (challengeId: number) => ({
       method: HttpMethod.GET,
       path: `/api/challenges/personal/${challengeId}`,
-      credentials: true,
     }),
 
     // 목록 (특정 카테고리)
@@ -34,21 +32,18 @@ const CHALLENGE_ENDPOINTS = {
     VERIFY: (challengeId: number) => ({
       method: HttpMethod.POST,
       path: `/api/challenges/personal/${challengeId}/verifications`,
-      credentials: true,
     }),
 
     // 인증 결과 조회 (롱폴링)
     VERIFICATION_RESULT: (challengeId: number) => ({
       method: HttpMethod.GET,
       path: `/api/challenges/personal/${challengeId}/verification/result`,
-      credentials: true,
     }),
 
     // 규약 조회
     RULES: (challengeId: number) => ({
       method: HttpMethod.GET,
       path: `/api/challenges/personal/${challengeId}/rules`,
-      credentials: true,
     }),
   },
 
@@ -65,33 +60,29 @@ const CHALLENGE_ENDPOINTS = {
     // 목록
     LIST: { method: HttpMethod.GET, path: '/api/challenges/group' },
     // 생성
-    CREATE: { method: HttpMethod.POST, path: '/api/challenges/group', credentials: true },
+    CREATE: { method: HttpMethod.POST, path: '/api/challenges/group' },
     // 수정
     MODIFY: (challengeId: number) => ({
       method: HttpMethod.PATCH,
       path: `/api/challenges/group/${challengeId}`,
-      credentials: true,
     }),
 
     // 삭제
     DELETE: (challengeId: number) => ({
       method: HttpMethod.DELETE,
       path: `/api/challenges/group/${challengeId}`,
-      credentials: true,
     }),
 
     // 인증 규약 조회
     RULES: (challengeId: number) => ({
       method: HttpMethod.GET,
       path: `/api/challenges/group/${challengeId}/rules`,
-      credentials: true,
     }),
 
     // 참여 이력 생성
     PARTICIPATE: (challengeId: number) => ({
       method: HttpMethod.POST,
       path: `/api/challenges/group/${challengeId}/participations`,
-      credentials: true,
     }),
 
     // 인증 관련
@@ -100,7 +91,6 @@ const CHALLENGE_ENDPOINTS = {
       LIST: (challengeId: number) => ({
         method: HttpMethod.GET,
         path: `/api/challenges/group/${challengeId}/verifications`,
-        credentials: true,
       }),
 
       // TODO: 인증 상세 조회
@@ -110,14 +100,12 @@ const CHALLENGE_ENDPOINTS = {
       SUBMIT: (challengeId: number) => ({
         method: HttpMethod.POST,
         path: `/api/challenges/group/${challengeId}/verifications`,
-        credentials: true,
       }),
 
       // 인증 결과 조회 (롱폴링)
       RESULT: (challengeId: number) => ({
         method: HttpMethod.GET,
         path: `/api/challenges/group/${challengeId}/verification/result`,
-        credentials: true,
       }),
 
       LIKES: {
@@ -155,16 +143,21 @@ const CHALLENGE_ENDPOINTS = {
     FEED: {
       method: HttpMethod.GET,
       path: `/api/challenges/group/verifications`,
-      credentials: true,
     },
   },
 
   ETC: {
     COUNT: {
       // 누적 사용자 인증수 조회
-      VERIFICATION: { method: HttpMethod.GET, path: `/api/challenges/verifications/count`, credentials: false },
+      VERIFICATION: { method: HttpMethod.GET, path: `/api/challenges/verifications/count` },
     },
   },
+}
+
+const a = {
+  1: 2,
+  2: 3,
+  3: 4,
 }
 
 const MEMBER_ENDPOINTS = {
@@ -174,68 +167,64 @@ const MEMBER_ENDPOINTS = {
     LOGOUT: (provider: LowercaseOAuthType) => ({
       method: HttpMethod.DELETE,
       path: `/oauth/${provider}/token`,
-      credentials: true,
     }),
-    RE_ISSUE: { method: HttpMethod.POST, path: '/auth/token/reissue', credentials: true }, // 토큰 재발급
+    RE_ISSUE: { method: HttpMethod.POST, path: '/auth/token/reissue' }, // 토큰 재발급
   },
 
   DUPLICATE_NICKNAME: { method: HttpMethod.GET, path: '/api/members/nickname' }, // 닉네임 중복 검사
 
   // CRUD
   SIGNUP: { method: HttpMethod.POST, path: '/api/members' }, // 회원가입
-  DETAILS: { method: HttpMethod.GET, path: '/api/members', credentials: true }, // 회원 정보 조회
-  MODIFY: { method: HttpMethod.PATCH, path: '/api/members', credentials: true }, // 회원정보 수정
-  UNREGISTER: { method: HttpMethod.DELETE, path: '/api/members', credentials: true }, // 회원 탈퇴
+  DETAILS: { method: HttpMethod.GET, path: '/api/members' }, // 회원 정보 조회
+  MODIFY: { method: HttpMethod.PATCH, path: '/api/members' }, // 회원정보 수정
+  UNREGISTER: { method: HttpMethod.DELETE, path: '/api/members' }, // 회원 탈퇴
 
   // 회원 정보
-  PROFILE_CARD: { method: HttpMethod.GET, path: '/api/members/profilecard', credentials: true }, // 프로필 카드 조회
-  LEAVES: { method: HttpMethod.GET, path: '/api/members/leaves', credentials: true }, // 나뭇잎 보유량 조회
+  PROFILE_CARD: { method: HttpMethod.GET, path: '/api/members/profilecard' }, // 프로필 카드 조회
+  LEAVES: { method: HttpMethod.GET, path: '/api/members/leaves' }, // 나뭇잎 보유량 조회
 
   FEEDBACK: {
-    GET_FEEDBACK: { method: HttpMethod.GET, path: '/api/members/feedback', credentials: true }, // 챌린지 피드백 조회
-    POST_FEEDBACK: { method: HttpMethod.POST, path: '/api/members/feedback', credentials: true }, //피드백 생성 요청
-    RESULT: { method: HttpMethod.GET, path: '/api/members/feedback/result', credentials: true }, //피드백 결과 조회(롱폴링)
+    GET_FEEDBACK: { method: HttpMethod.GET, path: '/api/members/feedback' }, // 챌린지 피드백 조회
+    POST_FEEDBACK: { method: HttpMethod.POST, path: '/api/members/feedback' }, //피드백 생성 요청
+    RESULT: { method: HttpMethod.GET, path: '/api/members/feedback/result' }, //피드백 결과 조회(롱폴링)
   },
 
   BADGES: {
-    LIST: { method: HttpMethod.GET, path: '/api/members/badges', credentials: true }, // 뱃지 조회
-    RECENT: { method: HttpMethod.GET, path: '/api/members/badges/recent', credentials: true }, //최근 획득 뱃지 조회
+    LIST: { method: HttpMethod.GET, path: '/api/members/badges' }, // 뱃지 조회
+    RECENT: { method: HttpMethod.GET, path: '/api/members/badges/recent' }, //최근 획득 뱃지 조회
   },
 
   // 알림
   NOTIFICATION: {
-    LIST: { method: HttpMethod.GET, path: '/api/members/notifications', credentials: true }, // 알림 조회
-    READ: { method: HttpMethod.PATCH, path: '/api/members/notifications', credentials: true }, // 알림 읽음 처리
+    LIST: { method: HttpMethod.GET, path: '/api/members/notifications' }, // 알림 조회
+    READ: { method: HttpMethod.PATCH, path: '/api/members/notifications' }, // 알림 읽음 처리
   },
 
   // 나뭇잎 상점
   STORE: {
     ORDERS: {
-      LIST: { method: HttpMethod.GET, path: '/api/members/products/list', credentials: true }, // 구매 내역
+      LIST: { method: HttpMethod.GET, path: '/api/members/products/list' }, // 구매 내역
     },
   },
 
   /** 챌린지 */
   CHALLENGE: {
     GROUP: {
-      CREATIONS: { method: HttpMethod.GET, path: '/api/members/challenges/group/creations', credentials: true }, // 생성한 챌린지
+      CREATIONS: { method: HttpMethod.GET, path: '/api/members/challenges/group/creations' }, // 생성한 챌린지
       PARTICIPATIONS: {
         method: HttpMethod.GET,
         path: '/api/members/challenges/group/participations',
-        credentials: true,
       }, // 참여한 단체 챌린지 목록 조회
 
       // 참여한 단체 챌린지 인증 내역을 일별로 조회
       VERIFICATIONS: (challengeId: number) => ({
         method: HttpMethod.GET,
         path: `/api/members/challenges/group/participations/${challengeId}/verifications`,
-        credentials: true,
       }),
       // 참여한 단체 챌린지 카운트 조회 (인증 페이지)
       COUNT: {
         method: HttpMethod.GET,
         path: `/api/members/challenges/group/participations/count`,
-        credentials: true,
       },
     },
   },
@@ -258,7 +247,6 @@ const STORE_ENDPOINTS = {
     ORDER: (dealId: number) => ({
       method: HttpMethod.POST,
       path: `/api/orders/${dealId}`,
-      credentials: true,
     }),
   },
   PRODUCTS: {
@@ -268,13 +256,12 @@ const STORE_ENDPOINTS = {
     ORDER: (productId: number) => ({
       method: HttpMethod.POST,
       path: `/api/orders/${productId}`,
-      credentials: true,
     }),
   },
   ETC: {
     COUNT: {
       // 누적 나뭇잎 수 조회
-      LEAVES: { method: HttpMethod.GET, path: '/api/leaves/count', credentials: false },
+      LEAVES: { method: HttpMethod.GET, path: '/api/leaves/count' },
     },
   },
 }

--- a/src/shared/constants/endpoint/endpoint.ts
+++ b/src/shared/constants/endpoint/endpoint.ts
@@ -5,6 +5,7 @@ import { HttpMethod } from '../http'
 export type EndpointType = {
   method: HttpMethod
   path: string
+  credentials?: boolean
 }
 
 const CHALLENGE_ENDPOINTS = {
@@ -20,6 +21,7 @@ const CHALLENGE_ENDPOINTS = {
     DETAILS: (challengeId: number) => ({
       method: HttpMethod.GET,
       path: `/api/challenges/personal/${challengeId}`,
+      credentials: true,
     }),
 
     // 목록 (특정 카테고리)
@@ -32,18 +34,21 @@ const CHALLENGE_ENDPOINTS = {
     VERIFY: (challengeId: number) => ({
       method: HttpMethod.POST,
       path: `/api/challenges/personal/${challengeId}/verifications`,
+      credentials: true,
     }),
 
     // 인증 결과 조회 (롱폴링)
     VERIFICATION_RESULT: (challengeId: number) => ({
       method: HttpMethod.GET,
       path: `/api/challenges/personal/${challengeId}/verification/result`,
+      credentials: true,
     }),
 
-    // 규칙
+    // 규약 조회
     RULES: (challengeId: number) => ({
       method: HttpMethod.GET,
       path: `/api/challenges/personal/${challengeId}/rules`,
+      credentials: true,
     }),
   },
 
@@ -60,29 +65,33 @@ const CHALLENGE_ENDPOINTS = {
     // 목록
     LIST: { method: HttpMethod.GET, path: '/api/challenges/group' },
     // 생성
-    CREATE: { method: HttpMethod.POST, path: '/api/challenges/group' },
+    CREATE: { method: HttpMethod.POST, path: '/api/challenges/group', credentials: true },
     // 수정
     MODIFY: (challengeId: number) => ({
       method: HttpMethod.PATCH,
       path: `/api/challenges/group/${challengeId}`,
+      credentials: true,
     }),
 
     // 삭제
     DELETE: (challengeId: number) => ({
       method: HttpMethod.DELETE,
       path: `/api/challenges/group/${challengeId}`,
+      credentials: true,
     }),
 
-    // 규약
+    // 인증 규약 조회
     RULES: (challengeId: number) => ({
       method: HttpMethod.GET,
       path: `/api/challenges/group/${challengeId}/rules`,
+      credentials: true,
     }),
 
-    // 참여
+    // 참여 이력 생성
     PARTICIPATE: (challengeId: number) => ({
       method: HttpMethod.POST,
       path: `/api/challenges/group/${challengeId}/participations`,
+      credentials: true,
     }),
 
     // 인증 관련
@@ -91,6 +100,7 @@ const CHALLENGE_ENDPOINTS = {
       LIST: (challengeId: number) => ({
         method: HttpMethod.GET,
         path: `/api/challenges/group/${challengeId}/verifications`,
+        credentials: true,
       }),
 
       // TODO: 인증 상세 조회
@@ -100,12 +110,14 @@ const CHALLENGE_ENDPOINTS = {
       SUBMIT: (challengeId: number) => ({
         method: HttpMethod.POST,
         path: `/api/challenges/group/${challengeId}/verifications`,
+        credentials: true,
       }),
 
       // 인증 결과 조회 (롱폴링)
       RESULT: (challengeId: number) => ({
         method: HttpMethod.GET,
         path: `/api/challenges/group/${challengeId}/verification/result`,
+        credentials: true,
       }),
 
       LIKES: {
@@ -143,13 +155,14 @@ const CHALLENGE_ENDPOINTS = {
     FEED: {
       method: HttpMethod.GET,
       path: `/api/challenges/group/verifications`,
+      credentials: true,
     },
   },
 
   ETC: {
     COUNT: {
       // 누적 사용자 인증수 조회
-      VERIFICATION: { method: HttpMethod.GET, path: `/api/challenges/verifications/count` },
+      VERIFICATION: { method: HttpMethod.GET, path: `/api/challenges/verifications/count`, credentials: false },
     },
   },
 }
@@ -161,61 +174,68 @@ const MEMBER_ENDPOINTS = {
     LOGOUT: (provider: LowercaseOAuthType) => ({
       method: HttpMethod.DELETE,
       path: `/oauth/${provider}/token`,
+      credentials: true,
     }),
-    RE_ISSUE: { method: HttpMethod.POST, path: '/auth/token/reissue' }, // 토큰 재발급
+    RE_ISSUE: { method: HttpMethod.POST, path: '/auth/token/reissue', credentials: true }, // 토큰 재발급
   },
 
   DUPLICATE_NICKNAME: { method: HttpMethod.GET, path: '/api/members/nickname' }, // 닉네임 중복 검사
 
   // CRUD
   SIGNUP: { method: HttpMethod.POST, path: '/api/members' }, // 회원가입
-  DETAILS: { method: HttpMethod.GET, path: '/api/members' }, // 내 정보 조회
-  MODIFY: { method: HttpMethod.PATCH, path: '/api/members' }, // 회원정보 수정
-  UNREGISTER: { method: HttpMethod.DELETE, path: '/api/members' }, // 회원 탈퇴
+  DETAILS: { method: HttpMethod.GET, path: '/api/members', credentials: true }, // 회원 정보 조회
+  MODIFY: { method: HttpMethod.PATCH, path: '/api/members', credentials: true }, // 회원정보 수정
+  UNREGISTER: { method: HttpMethod.DELETE, path: '/api/members', credentials: true }, // 회원 탈퇴
 
   // 회원 정보
-  PROFILE_CARD: { method: HttpMethod.GET, path: '/api/members/profilecard' }, // 프로필 카드 조회
-  LEAVES: { method: HttpMethod.GET, path: '/api/members/leaves' }, // 나뭇잎 개수 조회
+  PROFILE_CARD: { method: HttpMethod.GET, path: '/api/members/profilecard', credentials: true }, // 프로필 카드 조회
+  LEAVES: { method: HttpMethod.GET, path: '/api/members/leaves', credentials: true }, // 나뭇잎 보유량 조회
 
   FEEDBACK: {
-    GET_FEEDBACK: { method: HttpMethod.GET, path: '/api/members/feedback' }, // 챌린지 피드백 조회
-    POST_FEEDBACK: { method: HttpMethod.POST, path: '/api/members/feedback' }, //피드백 생성 요청
-    RESULT: { method: HttpMethod.GET, path: '/api/members/feedback/result' }, //피드백 결과 조회(롱폴링)
+    GET_FEEDBACK: { method: HttpMethod.GET, path: '/api/members/feedback', credentials: true }, // 챌린지 피드백 조회
+    POST_FEEDBACK: { method: HttpMethod.POST, path: '/api/members/feedback', credentials: true }, //피드백 생성 요청
+    RESULT: { method: HttpMethod.GET, path: '/api/members/feedback/result', credentials: true }, //피드백 결과 조회(롱폴링)
   },
 
   BADGES: {
-    LIST: { method: HttpMethod.GET, path: '/api/members/badges' }, // 뱃지 조회
-    RECENT: { method: HttpMethod.GET, path: '/api/members/badges/recent' }, //최근 획득 뱃지 조회
+    LIST: { method: HttpMethod.GET, path: '/api/members/badges', credentials: true }, // 뱃지 조회
+    RECENT: { method: HttpMethod.GET, path: '/api/members/badges/recent', credentials: true }, //최근 획득 뱃지 조회
   },
 
   // 알림
   NOTIFICATION: {
-    LIST: { method: HttpMethod.GET, path: '/api/members/notifications' }, // 알림 조회
-    READ: { method: HttpMethod.PATCH, path: '/api/members/notifications' }, // 알림 읽음 처리
+    LIST: { method: HttpMethod.GET, path: '/api/members/notifications', credentials: true }, // 알림 조회
+    READ: { method: HttpMethod.PATCH, path: '/api/members/notifications', credentials: true }, // 알림 읽음 처리
   },
 
   // 나뭇잎 상점
   STORE: {
     ORDERS: {
-      LIST: { method: HttpMethod.GET, path: '/api/members/products/list' }, // 구매 내역
+      LIST: { method: HttpMethod.GET, path: '/api/members/products/list', credentials: true }, // 구매 내역
     },
   },
 
   /** 챌린지 */
   CHALLENGE: {
     GROUP: {
-      CREATIONS: { method: HttpMethod.GET, path: '/api/members/challenges/group/creations' }, // 생성한 챌린지
-      PARTICIPATIONS: { method: HttpMethod.GET, path: '/api/members/challenges/group/participations' }, // 내가 참여한 챌린지
+      CREATIONS: { method: HttpMethod.GET, path: '/api/members/challenges/group/creations', credentials: true }, // 생성한 챌린지
+      PARTICIPATIONS: {
+        method: HttpMethod.GET,
+        path: '/api/members/challenges/group/participations',
+        credentials: true,
+      }, // 참여한 단체 챌린지 목록 조회
 
-      // 챌린지 인증 내역
+      // 참여한 단체 챌린지 인증 내역을 일별로 조회
       VERIFICATIONS: (challengeId: number) => ({
         method: HttpMethod.GET,
         path: `/api/members/challenges/group/participations/${challengeId}/verifications`,
+        credentials: true,
       }),
       // 참여한 단체 챌린지 카운트 조회 (인증 페이지)
       COUNT: {
         method: HttpMethod.GET,
         path: `/api/members/challenges/group/participations/count`,
+        credentials: true,
       },
     },
   },
@@ -238,6 +258,7 @@ const STORE_ENDPOINTS = {
     ORDER: (dealId: number) => ({
       method: HttpMethod.POST,
       path: `/api/orders/${dealId}`,
+      credentials: true,
     }),
   },
   PRODUCTS: {
@@ -247,12 +268,13 @@ const STORE_ENDPOINTS = {
     ORDER: (productId: number) => ({
       method: HttpMethod.POST,
       path: `/api/orders/${productId}`,
+      credentials: true,
     }),
   },
   ETC: {
     COUNT: {
       // 누적 나뭇잎 수 조회
-      LEAVES: { method: HttpMethod.GET, path: '/api/leaves/count' },
+      LEAVES: { method: HttpMethod.GET, path: '/api/leaves/count', credentials: false },
     },
   },
 }
@@ -264,72 +286,10 @@ const CHATBOT_ENDPOINTS = {
   CHATTING: { method: HttpMethod.POST, path: '/api/chatbot/recommendation/free-text' },
 }
 
-/** 관리자 (v3 개발)*/
-// const ADMIN_ENDPOINTS = {
-//   CHALLENGE: {
-//     EVENT: {
-//       // 이벤트 챌린지 생성
-//       CREATE: { method: HttpMethod.POST, path: '/api/admin/challenges/event' },
-//     },
-//     PERSONAL: {
-//       // 템플릿
-//       TEMPLATE: {
-//         GET: { method: HttpMethod.GET, path: '/api/admin/challenges/personal' }, // 조회
-//         CREATE: { method: HttpMethod.POST, path: '/api/admin/challenges/personal' }, // 생성
-//         // 개인 챌린지 템플릿 수정
-//         UPDATE: (templateId: number) => ({
-//           method: HttpMethod.PATCH,
-//           path: `/api/admin/challenges/personal/${templateId}`,
-//         }),
-//         // 개인 챌린지 템플릿 삭제
-//         DELETE: (templateId: number) => ({
-//           method: HttpMethod.DELETE,
-//           path: `/api/admin/challenges/personal/${templateId}`,
-//         }),
-//       },
-//       PRODUCT: {
-//         // 일반 상품
-//         STORE: {
-//           // 등록
-//           CREATE: { method: HttpMethod.POST, path: '/api/admin/products' },
-
-//           // 수정
-//           UPDATE: (productId: number) => ({
-//             method: HttpMethod.PATCH,
-//             path: `/api/admin/products/${productId}`,
-//           }),
-
-//           // 삭제
-//           DELETE: (productId: number) => ({
-//             method: HttpMethod.DELETE,
-//             path: `/api/admin/products/${productId}`,
-//           }),
-//         },
-//         // 타임딜
-//         TIME_DEAL: {
-//           // 등록ㄴ
-//           CREATE: { method: HttpMethod.POST, path: '/api/admin/timedeals' },
-//           // 수정
-//           UPDATE: (dealId: number) => ({
-//             method: HttpMethod.PATCH,
-//             path: `/api/admin/timedeals/${dealId}`,
-//           }),
-//           // 삭제
-//           DELETE: (dealId: number) => ({
-//             method: HttpMethod.DELETE,
-//             path: `/api/admin/timedeals/${dealId}`,
-//           }),
-//         },
-//       },
-//     },
-//   },
-// }
-
 export const ENDPOINTS = {
   CHALLENGE: CHALLENGE_ENDPOINTS,
   MEMBERS: MEMBER_ENDPOINTS,
   STORE: STORE_ENDPOINTS,
   CHATBOT: CHATBOT_ENDPOINTS,
   S3: S3_ENDPOINTS,
-  // ADMIN: ADMIN_ENDPOINTS,
 } as const

--- a/src/shared/constants/route/route.ts
+++ b/src/shared/constants/route/route.ts
@@ -18,6 +18,11 @@ const MEMBER_URL = {
     value: '/member/login',
     isProtected: false,
   },
+  CALLBACK: {
+    name: '소셜 로그인 콜백',
+    value: (provider: string) => `/member/${provider}/callback`,
+    isProtected: false,
+  },
   SIGNUP: {
     name: '회원가입',
     value: '/member/signup',

--- a/src/shared/lib/api/client-fetcher/client-fetcher.ts
+++ b/src/shared/lib/api/client-fetcher/client-fetcher.ts
@@ -10,7 +10,7 @@ export async function clientFetchRequest<T>(
   isRetry = false,
 ): Promise<ApiResponse<T>> {
   /** Request */
-  const { method, path, credentials } = endpoint
+  const { method, path } = endpoint
   const url = new URL(BASE_URL + path)
 
   if (options.query) {
@@ -34,7 +34,7 @@ export async function clientFetchRequest<T>(
     method,
     headers,
     body,
-    ...(credentials ? { credentials: 'include' } : {}),
+    credentials: 'include',
   })
 
   /** Response */

--- a/src/shared/lib/api/client-fetcher/client-fetcher.ts
+++ b/src/shared/lib/api/client-fetcher/client-fetcher.ts
@@ -1,11 +1,9 @@
 import { handleAuthError } from '@shared/config/tanstack-query/utils'
 import { EndpointType } from '@shared/constants/endpoint/endpoint'
 
+import { BASE_URL } from '../fetcher'
 import { ApiResponse, ErrorResponse, OptionsType } from '../type'
 import { refreshClientAccessToken } from './client-reissue'
-
-//TODO: dev/prod 환경에 따라 서로 다른 도메인 설정
-const BASE_URL = 'https://leafresh.app'
 
 export async function clientFetchRequest<T>(
   endpoint: EndpointType,

--- a/src/shared/lib/api/client-fetcher/client-fetcher.ts
+++ b/src/shared/lib/api/client-fetcher/client-fetcher.ts
@@ -1,4 +1,3 @@
-import { handleAuthError } from '@shared/config/tanstack-query/utils'
 import { EndpointType } from '@shared/constants/endpoint/endpoint'
 
 import { BASE_URL } from '../fetcher'
@@ -11,7 +10,7 @@ export async function clientFetchRequest<T>(
   isRetry = false,
 ): Promise<ApiResponse<T>> {
   /** Request */
-  const { method, path } = endpoint
+  const { method, path, credentials } = endpoint
   const url = new URL(BASE_URL + path)
 
   if (options.query) {
@@ -35,7 +34,7 @@ export async function clientFetchRequest<T>(
     method,
     headers,
     body,
-    credentials: 'include',
+    ...(credentials ? { credentials: 'include' } : {}),
   })
 
   /** Response */
@@ -55,7 +54,7 @@ export async function clientFetchRequest<T>(
           data: null,
         }
         /** 미인증 유저에게는 토스트로 알림 */
-        handleAuthError(error)
+        // handleAuthError(error)
         throw error
       }
     }

--- a/src/shared/lib/api/client-fetcher/client-reissue.ts
+++ b/src/shared/lib/api/client-fetcher/client-reissue.ts
@@ -1,11 +1,10 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { useToastStore } from '@shared/context/toast/ToastStore'
 
+import { BASE_URL } from '../fetcher'
+
 let isRefreshing = false
 let refreshPromise: Promise<void> | null = null
-
-//TODO: dev/prod 환경에 따라 서로 다른 도메인 설정
-const BASE_URL = 'https://leafresh.app'
 
 export async function refreshClientAccessToken(): Promise<void> {
   const openToast = useToastStore.getState().open

--- a/src/shared/lib/api/client-fetcher/client-reissue.ts
+++ b/src/shared/lib/api/client-fetcher/client-reissue.ts
@@ -1,5 +1,4 @@
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
-import { useToastStore } from '@shared/context/toast/ToastStore'
 
 import { BASE_URL } from '../fetcher'
 
@@ -7,8 +6,6 @@ let isRefreshing = false
 let refreshPromise: Promise<void> | null = null
 
 export async function refreshClientAccessToken(): Promise<void> {
-  const openToast = useToastStore.getState().open
-
   if (isRefreshing) return refreshPromise ?? Promise.resolve()
 
   isRefreshing = true
@@ -17,7 +14,7 @@ export async function refreshClientAccessToken(): Promise<void> {
     try {
       const response = await fetch(`${BASE_URL}${ENDPOINTS.MEMBERS.AUTH.RE_ISSUE}`, {
         method: 'POST',
-        credentials: 'include', // 쿠키 포함
+        credentials: 'include', // 재발급은 쿠키 포함
       })
 
       if (!response.ok) {

--- a/src/shared/lib/api/fetcher/fetcher.ts
+++ b/src/shared/lib/api/fetcher/fetcher.ts
@@ -6,6 +6,8 @@ import { clientFetchRequest } from '../client-fetcher'
 import { serverFetchRequest } from '../server-fetcher'
 import { ApiResponse, OptionsType } from '../type'
 
+export const BASE_URL = 'https://be.dev-leafresh.app'
+
 export const fetchRequest = async <T>(endpoint: EndpointType, options: OptionsType = {}): Promise<ApiResponse<T>> => {
   // 서버 환경
   if (isServer) {

--- a/src/shared/lib/api/fetcher/fetcher.ts
+++ b/src/shared/lib/api/fetcher/fetcher.ts
@@ -6,7 +6,7 @@ import { clientFetchRequest } from '../client-fetcher'
 import { serverFetchRequest } from '../server-fetcher'
 import { ApiResponse, OptionsType } from '../type'
 
-export const BASE_URL = 'https://be.dev-leafresh.app'
+export const BASE_URL = 'https://springboot.dev-leafresh.app'
 
 export const fetchRequest = async <T>(endpoint: EndpointType, options: OptionsType = {}): Promise<ApiResponse<T>> => {
   // 서버 환경

--- a/src/shared/lib/api/server-fetcher/server-fetcher.ts
+++ b/src/shared/lib/api/server-fetcher/server-fetcher.ts
@@ -13,7 +13,7 @@ export async function serverFetchRequest<T>(
   options: OptionsType = {},
   isRetry = false,
 ): Promise<ApiResponse<T>> {
-  const { method, path, credentials } = endpoint
+  const { method, path } = endpoint
   const url = new URL(BASE_URL + path)
 
   if (options.query) {
@@ -43,7 +43,7 @@ export async function serverFetchRequest<T>(
     method,
     headers: {
       ...headers,
-      ...(credentials ? { Cookie: cookieHeader } : {}),
+      Cookie: cookieHeader,
     },
     body,
   })

--- a/src/shared/lib/api/server-fetcher/server-fetcher.ts
+++ b/src/shared/lib/api/server-fetcher/server-fetcher.ts
@@ -13,7 +13,7 @@ export async function serverFetchRequest<T>(
   options: OptionsType = {},
   isRetry = false,
 ): Promise<ApiResponse<T>> {
-  const { method, path } = endpoint
+  const { method, path, credentials } = endpoint
   const url = new URL(BASE_URL + path)
 
   if (options.query) {
@@ -43,7 +43,7 @@ export async function serverFetchRequest<T>(
     method,
     headers: {
       ...headers,
-      Cookie: cookieHeader,
+      ...(credentials ? { Cookie: cookieHeader } : {}),
     },
     body,
   })

--- a/src/shared/lib/api/server-fetcher/server-fetcher.ts
+++ b/src/shared/lib/api/server-fetcher/server-fetcher.ts
@@ -4,10 +4,9 @@ import { cookies } from 'next/headers'
 
 import { EndpointType } from '@shared/constants/endpoint/endpoint'
 
+import { BASE_URL } from '../fetcher'
 import { ApiResponse, ErrorResponse, OptionsType } from '../type'
 import { refreshServerAccessToken } from './server-reissue'
-
-const BASE_URL = 'https://leafresh.app'
 
 export async function serverFetchRequest<T>(
   endpoint: EndpointType,

--- a/src/shared/lib/api/server-fetcher/server-reissue.ts
+++ b/src/shared/lib/api/server-fetcher/server-reissue.ts
@@ -18,7 +18,6 @@ export async function refreshServerAccessToken(): Promise<void> {
     try {
       // ✅ SSR: 쿠키 수동 주입
       const cookieStore = await cookies()
-
       const cookieHeader = cookieStore
         .getAll()
         .map(({ name, value }) => `${name}=${value}`)
@@ -27,7 +26,7 @@ export async function refreshServerAccessToken(): Promise<void> {
       const response = await fetch(`${BASE_URL}${ENDPOINTS.MEMBERS.AUTH.RE_ISSUE}`, {
         method: 'POST',
         headers: {
-          Cookie: cookieHeader,
+          Cookie: cookieHeader, // 재발급은 쿠키 포함
         },
       })
       if (!response.ok) {

--- a/src/shared/lib/api/server-fetcher/server-reissue.ts
+++ b/src/shared/lib/api/server-fetcher/server-reissue.ts
@@ -4,11 +4,10 @@ import { cookies } from 'next/headers'
 
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 
+import { BASE_URL } from '../fetcher'
+
 let isRefreshing = false
 let refreshPromise: Promise<void> | null = null
-
-//TODO: dev/prod 환경에 따라 서로 다른 도메인 설정
-const BASE_URL = 'https://leafresh.app'
 
 export async function refreshServerAccessToken(): Promise<void> {
   if (isRefreshing) return refreshPromise ?? Promise.resolve()


### PR DESCRIPTION
# 🍀 무엇을 위한 PR인가요?

local / dev / prod 환경에 따른 리다이렉트 URL 설정을 백엔드와 협업하여 재구성하였습니다.

## 관련 이슈

Relates to #120
Closes #207 

# 주요 변경사항

## 개발환경 (쿠키 저장 및 교환)

로컬  : 내부 DNS 설정을 통해 https://localhost:3000 -> https://local-dev.leafresh.app 으로 설정하였습니다.
백엔드 : be.dev-leafresh.app

쿠키 도메인 : .dev-leafresh.app 즉, 서브 도메인으로 설정하여 도메인이 다른 사이트간 쿠키교환을 가능하게 하였습니다.

`package.json` 또한 도메인과 포트를 지정하였습니다.

```json
"scripts": {
  "dev": "next dev -H local.dev-leafresh.app -p 3000 --turbopack --experimental-https",
}
```

## 소셜 로그인 / 소셜 콜백 API 변경
- 소셜 로그인시에 요청을 보내는 (FE) 오리진을 담아서 보냅니다.
- 소셜 콜백에서는 전달받은 JWT (오리진 암호화)를 재전송합니다.


### PR간 오류 혹은 질문은 댓글로 남겨주세요!
