### PR TITLE
FE: PR(feat) : 헤더 뒤로가기 버튼 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,6 @@ RUN addgroup -g 1001 nodejs && adduser -u 1001 -G nodejs -s /bin/sh -D nodejs &&
 
 # Copy only what is needed to run
 COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/pnpm-lock.yaml ./
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public

--- a/src/app/(with-layout)/(with-header)/MainPage.tsx
+++ b/src/app/(with-layout)/(with-header)/MainPage.tsx
@@ -24,8 +24,6 @@ const MainPage = (): ReactNode => {
     ...QUERY_OPTIONS.CHALLENGE.GROUP.CATEGORIES,
   })
 
-  console.log('categoiresData: ', categoriesData)
-
   const { data: eventData } = useQuery({
     queryKey: QUERY_KEYS.CHALLENGE.EVENT.LIST,
     queryFn: getEventChallengeList,
@@ -41,9 +39,6 @@ const MainPage = (): ReactNode => {
   const categories: GroupChallengeCategory[] = categoriesData?.data?.categories ?? []
   const eventChallenges: EventChallenge[] = eventData?.data.eventChallenges ?? []
   const personalChallenges: PersonalChallengeType[] = personalData?.data.personalChallenges ?? []
-
-  console.log('categoriesData: ', categoriesData)
-  console.log('categories: ', categories)
 
   return (
     <Container>

--- a/src/app/(with-layout)/(with-header)/member/[provider]/callback/CallbackPage.tsx
+++ b/src/app/(with-layout)/(with-header)/member/[provider]/callback/CallbackPage.tsx
@@ -8,26 +8,33 @@ import { useQuery } from '@tanstack/react-query'
 
 import { useOAuthStateStore } from '@entities/member/context/OAuthStateStore'
 import { useOAuthUserStore } from '@entities/member/context/OAuthUserStore'
+import { UserInfo, useUserStore } from '@entities/member/context/UserStore'
 import { LowercaseOAuthType } from '@entities/member/type'
 import { LoginCallback } from '@features/member/api/oauth-callback'
+import { ProfileResponse } from '@features/member/api/profile/get-member-profile'
 import Loading from '@shared/components/loading'
 import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
 import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
+import { getQueryClient } from '@shared/config/tanstack-query/queryClient'
+import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { URL } from '@shared/constants/route/route'
 import { ToastType } from '@shared/context/toast/type'
 import { useToast } from '@shared/hooks/useToast/useToast'
+import { fetchRequest } from '@shared/lib/api'
 
 interface CallbackPageProps {
   provider: LowercaseOAuthType
 }
 
 const CallbackPage = ({ provider }: CallbackPageProps) => {
+  const queryClient = getQueryClient()
   const router = useRouter()
   const searchParams = useSearchParams()
   const openToast = useToast()
 
   const { setOAuthUserInfo } = useOAuthUserStore()
   const { state } = useOAuthStateStore()
+  const { userInfo, setUserInfo, clearUserInfo } = useUserStore()
 
   const code = searchParams.get('code')
   const { data, isLoading, isError } = useQuery({
@@ -55,7 +62,31 @@ const CallbackPage = ({ provider }: CallbackPageProps) => {
     if (!isMember) {
       router.replace(URL.MEMBER.SIGNUP.value)
     } else {
-      /** ✅ 주의 : UserStore 정보를 받아오지 않는 이유는 AT+RT 받기를 성공했으면 언젠가는 데이터를 불러올 수 있기 때문이다! */
+      // ✅ 로그인 성공 → 유저 정보 요청 → 전역 상태에 저장
+      ;(async () => {
+        try {
+          const { data: profileData } = await fetchRequest<ProfileResponse>(ENDPOINTS.MEMBERS.DETAILS)
+          if (profileData) {
+            const { nickname, email, profileImageUrl, treeImageUrl, treeLevelId, treeLevelName } = profileData
+
+            const userInfo: UserInfo = {
+              nickname,
+              email,
+              imageUrl: profileImageUrl,
+              treeState: {
+                level: treeLevelId,
+                name: treeLevelName,
+                imageUrl: treeImageUrl,
+              },
+            }
+
+            setUserInfo(userInfo)
+          }
+        } catch (err) {
+          console.warn('유저 정보 가져오기 실패', err)
+        }
+      })()
+
       openToast(ToastType.Success, '로그인 성공')
       router.replace(URL.MAIN.INDEX.value)
     }

--- a/src/app/(with-layout)/(with-header)/store/page.tsx
+++ b/src/app/(with-layout)/(with-header)/store/page.tsx
@@ -1,4 +1,4 @@
-import { dehydrate } from '@tanstack/react-query'
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
 
 import { getProducts, ProductsResponse } from '@features/store/api/get-products'
 import { getTimeDealProducts } from '@features/store/api/get-timedeals'
@@ -44,9 +44,9 @@ const Page = async () => {
     const dehydratedState = dehydrate(queryClient)
 
     return (
-      // <HydrationBoundary state={dehydratedState}>
-      <StorePage />
-      // </HydrationBoundary>
+      <HydrationBoundary state={dehydratedState}>
+        <StorePage />
+      </HydrationBoundary>
     )
   } catch (err) {
     console.error('[SSR] 그룹 챌린지 상세 데이터 로드 실패:', err)

--- a/src/features/challenge/api/get-group-challenge-categories.ts
+++ b/src/features/challenge/api/get-group-challenge-categories.ts
@@ -13,8 +13,5 @@ type GroupChallengeCategoryListResponse = {
 }
 
 export const getGroupChallengeCategoryList = () => {
-  console.log('entered getGroupChallengeCategoryList ')
-
-  console.log('endpoint:', ENDPOINTS.CHALLENGE.GROUP.CATEGORIES)
   return fetchRequest<GroupChallengeCategoryListResponse>(ENDPOINTS.CHALLENGE.GROUP.CATEGORIES)
 }

--- a/src/features/challenge/api/get-group-challenge-list.ts
+++ b/src/features/challenge/api/get-group-challenge-list.ts
@@ -1,3 +1,4 @@
+import { ChallengeCategoryType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api'
 import { InfiniteScrollResponse } from '@shared/types/api'
@@ -20,6 +21,8 @@ export interface FetchGroupChallengesParams {
 export interface GroupChallengeItem {
   id: number
   title: string
+  category: ChallengeCategoryType
+  description: string
   thumbnailUrl: string
   leafReward: number
   startDate: DateFormatString

--- a/src/features/challenge/api/participate/get-group-participant-list.ts
+++ b/src/features/challenge/api/participate/get-group-participant-list.ts
@@ -27,7 +27,7 @@ export type Verification = {
 }
 
 export type GroupChallengeParticipateList = InfiniteScrollResponse<{
-  items: Verification[]
+  verifications: Verification[]
 }>
 
 export type GetGroupChallengeParticipateListResponse = GroupChallengeParticipateList

--- a/src/features/challenge/api/participate/verification/get-verifycation-details.ts
+++ b/src/features/challenge/api/participate/verification/get-verifycation-details.ts
@@ -4,7 +4,7 @@ import { fetchRequest } from '@shared/lib/api/fetcher'
 import { ISOFormatString } from '@shared/types/date'
 
 export type VerificationDetailResponse = {
-  id: 0
+  id: number
   nickname: string
   profileImageUrl: string
   isLiked: boolean // 로그인한 사용자의 좋아요 여부. 로그인하지 않은 사용자는 false 고정
@@ -22,7 +22,12 @@ export type VerificationDetailResponse = {
   updatedAt: ISOFormatString
 }
 
-export const getVerificationDetails = (challengeId: number, verificationId: number) => {
+export type VerificationDetailVariables = {
+  challengeId: number
+  verificationId: number
+}
+
+export const getVerificationDetails = ({ challengeId, verificationId }: VerificationDetailVariables) => {
   return fetchRequest<VerificationDetailResponse>(
     ENDPOINTS.CHALLENGE.GROUP.VERIFICATION.DETAILS(challengeId, verificationId),
   )

--- a/src/features/challenge/components/challenge/group/feed/FeedList.tsx
+++ b/src/features/challenge/components/challenge/group/feed/FeedList.tsx
@@ -3,11 +3,13 @@ import { useRouter } from 'next/navigation'
 import { ReactNode, useEffect, useRef } from 'react'
 import styled from '@emotion/styled'
 
+import { CHALLENGE_CATEGORY_PAIRS, convertLanguage } from '@entities/challenge/constant'
 import { ChallengeCategoryType } from '@entities/challenge/type'
 import { Verification } from '@features/challenge/api/feed/get-feed-list'
 import { useInfiniteGroupChallengeFeedList } from '@features/challenge/hook/useInfiniteFeedList'
 import Loading from '@shared/components/loading'
 import NoContent from '@shared/components/no-content/no-content'
+import { URL } from '@shared/constants/route/route'
 import { responsiveHorizontalPadding } from '@shared/styles/ResponsiveStyle'
 import { ISOFormatString } from '@shared/types/date'
 
@@ -75,8 +77,13 @@ export const FeedList = ({ category, className }: FeedListProps): ReactNode => {
   const router = useRouter()
 
   /** 인증 피드 목록 조회 API */
-  const { data, fetchNextPage, hasNextPage, isLoading, isFetchingNextPage } =
-    useInfiniteGroupChallengeFeedList(category)
+  const {
+    data: verificationData,
+    fetchNextPage,
+    hasNextPage,
+    isLoading,
+    isFetchingNextPage,
+  } = useInfiniteGroupChallengeFeedList(category)
 
   const observerRef = useRef<HTMLDivElement | null>(null)
 
@@ -104,22 +111,28 @@ export const FeedList = ({ category, className }: FeedListProps): ReactNode => {
     }
   }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
-  // TODO: 실제 데이터로 교체하기
-  // const verifications = verificationData?.pages.flatMap(page => page?.data?.items || []) ?? []
-  const verifications = verificationsDummy
-  console.log(verifications)
+  const verifications = verificationData?.pages.flatMap(page => page?.data?.verifications || []) ?? []
+  // const verifications = verificationsDummy
 
   let contents
   if (isLoading) {
     contents = <Loading />
   } else if (!verifications || verifications.length === 0) {
     /** 검색값이 없는 경우 */
+    let title: string
+    if (category === 'ALL') {
+      title = `챌린지가 없습니다`
+    } else {
+      const korCategory = convertLanguage(CHALLENGE_CATEGORY_PAIRS, 'eng', 'kor')(category) as string
+      title = `${korCategory}\n 인증 내역이 없습니다`
+    }
     contents = (
       <StyledNoContent
-        title='검색 결과가 없습니다'
-        buttonText='챌린지 생성하기'
-        // TODO: 메인의 단체 챌린지로 라우팅 (페이지의 섹션을 나눠서 딱 챌린지 쪽으로 포커스 가게 만들기)
-        clickHandler={() => {}}
+        title={title}
+        buttonText='챌린지 참여하기'
+        clickHandler={() => {
+          router.push(URL.MAIN.INDEX.value)
+        }}
       />
     )
   } else {

--- a/src/features/challenge/components/challenge/participate/ChallengeParticipatePage.tsx
+++ b/src/features/challenge/components/challenge/participate/ChallengeParticipatePage.tsx
@@ -70,7 +70,8 @@ export default function ChallengeParticipatePage() {
   }, [hasError, hasNextPage, isFetchingNextPage, fetchNextPage])
 
   let challengeContents
-  if (realChallenges && realChallenges.length > 0) {
+  const isChallengeExists: boolean = realChallenges && realChallenges.length > 0
+  if (isChallengeExists) {
     challengeContents = (
       <CardList>
         {realChallenges.map(challenge => {
@@ -108,7 +109,7 @@ export default function ChallengeParticipatePage() {
         <SwitchTap tabs={tabLabels} currentIndex={tab} onChange={setTab} />
       </SwitchTapContainer>
 
-      <CardListContainer>
+      <CardListContainer isChallengeExists={isChallengeExists}>
         {challengeContents}
         {isFetchingNextPage && <Loading />}
         {!hasNextPage && !isLoading && realChallenges.length > 0 && <EndMessage>모든 챌린지를 불러왔습니다</EndMessage>}
@@ -141,14 +142,15 @@ const SwitchTapContainer = styled.div`
 `
 
 // 카드 리스트 컨테이너
-const CardListContainer = styled.div`
+const CardListContainer = styled.div<{ isChallengeExists: boolean }>`
   width: 100%;
-  flex: 1; /* 남은 공간 모두 차지하도록 변경 */
+  height: ${({ isChallengeExists }) => (!isChallengeExists ? '100%' : 'fit-content')};
 
   display: flex;
   align-self: center;
   flex-direction: column; /* 세로 방향으로 설정 */
   overflow: hidden; /* 내부 스크롤만 보이도록 설정 */
+  gap: 24px;
 `
 
 const ObserverTrigger = styled.div`

--- a/src/features/challenge/components/challenge/participate/GroupChallengeParticipantCard.tsx
+++ b/src/features/challenge/components/challenge/participate/GroupChallengeParticipantCard.tsx
@@ -79,11 +79,6 @@ const CardContainer = styled.div`
   display: flex;
   overflow: hidden;
   cursor: pointer;
-  transition: transform 0.2s;
-  //마우스 호버
-  &:hover {
-    transform: translateY(-2px);
-  }
 `
 
 const LeftSection = styled.div`

--- a/src/features/challenge/components/challenge/participate/GroupVerificationPage.tsx
+++ b/src/features/challenge/components/challenge/participate/GroupVerificationPage.tsx
@@ -76,7 +76,7 @@ export default function GroupVerificationPage({ participateId }: { participateId
       </GridWrapper>
 
       <ButtonGroup>
-        <QuestionButton>문의하기</QuestionButton>
+        {/* <QuestionButton>문의하기</QuestionButton> */}
         {todayStatus === 'NOT_SUBMITTED' && <ActionButton onClick={handleCapture}>인증하기</ActionButton>}
 
         {todayStatus === 'PENDING_APPROVAL' && <DisabledButton>인증 중</DisabledButton>}
@@ -122,7 +122,7 @@ const Count = styled.div`
 `
 const GridWrapper = styled.div`
   width: 100%;
-  display: flex;
+  display: grid;
   justify-content: center;
   grid-template-columns: repeat(2, 1fr);
   gap: 16px;

--- a/src/features/challenge/components/challenge/participate/list/ChallengeGroupParticipateList.tsx
+++ b/src/features/challenge/components/challenge/participate/list/ChallengeGroupParticipateList.tsx
@@ -94,9 +94,8 @@ const ChallengeGroupParticipateList = ({ challengeId }: ChallengeGroupParticipat
 
   const challenge = challengeData?.data
 
-  // TODO: 실제 데이터로 교체하기
-  // const verifications = verificationData?.pages.flatMap(page => page?.data?.items || []) ?? []
-  const verifications = verificationsDummy
+  const verifications = verificationData?.pages.flatMap(page => page?.data?.verifications || []) ?? []
+  // const verifications = verificationsDummy
 
   const observerRef = useRef<HTMLDivElement>(null)
 

--- a/src/features/challenge/components/challenge/participate/verification/details/VerificationDetails.tsx
+++ b/src/features/challenge/components/challenge/participate/verification/details/VerificationDetails.tsx
@@ -60,7 +60,7 @@ const VerificationDetails = ({ challengeId, verificationId, className }: Verific
 
   const { data: verificationData } = useQuery({
     queryKey: QUERY_KEYS.CHALLENGE.GROUP.VERIFICATION.DETAILS(challengeId, verificationId),
-    queryFn: () => getVerificationDetails(challengeId, verificationId),
+    queryFn: () => getVerificationDetails({ challengeId, verificationId }),
     ...QUERY_OPTIONS.CHALLENGE.GROUP.VERIFICATION.DETAILS,
   })
 
@@ -104,7 +104,10 @@ const VerificationDetails = ({ challengeId, verificationId, className }: Verific
   )
 
   const verifications: VerificationDetailResponse = verificationData?.data ?? ({} as VerificationDetailResponse)
+  console.log(verifications)
+
   const comments: CommentResponse = commentData?.data ?? ({} as CommentResponse)
+  console.log(comments)
 
   // const verifications: VerificationDetailResponse = verificationData?.data ?? (dummypost as VerificationDetailResponse)
   // const comments: CommentResponse = commentData?.data ?? (dummycomments as CommentResponse)

--- a/src/features/challenge/components/challenge/participate/verification/verification-card.tsx
+++ b/src/features/challenge/components/challenge/participate/verification/verification-card.tsx
@@ -64,7 +64,9 @@ const VerificationCard = ({ challengeId, verificationData, className }: Verifica
   )
 
   /** 좋아요 핸들러 */
-  const toggleLike = () => {
+  const toggleLike = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation()
+
     // #0. 로그인 상태가 아닐 때
     if (!isLoggedIn) {
       openConfirmModal({
@@ -100,6 +102,10 @@ const VerificationCard = ({ challengeId, verificationData, className }: Verifica
     const url = `${window.location.origin}${URL.CHALLENGE.GROUP.VERIFICATION.LIST.value(challengeId)}`
     copyToClipboard(url)
   }
+
+  const handleDetailsRoute = () => {
+    router.push(URL.CHALLENGE.GROUP.VERIFICATION.DETAILS.value(challengeId, verificationId))
+  }
   return (
     <Wrapper className={className}>
       <HeaderWrapper>
@@ -112,7 +118,7 @@ const VerificationCard = ({ challengeId, verificationData, className }: Verifica
         </ProfileWrapper>
       </HeaderWrapper>
 
-      <VerificationWrapper>
+      <VerificationWrapper onClick={handleDetailsRoute}>
         <ImageWrapper>
           <VerificationImage src={verificationImageUrl} alt='인증 이미지' fill />
           <Badge className='badge'>{category_kor}</Badge>

--- a/src/features/main/components/sections/group-challenge-section.tsx
+++ b/src/features/main/components/sections/group-challenge-section.tsx
@@ -27,13 +27,7 @@ interface GroupChallengeSectionsProps {
 export const GroupChallengeSections = ({ categories, className }: GroupChallengeSectionsProps): ReactNode => {
   const router = useRouter()
 
-  console.log('groupchallengesections : categoires', categories)
-  console.log('categories[0]: ', categories[0])
-  console.log('categories[0]: ', categories[0]?.imageUrl)
-
   const [category, setCategory] = useState<FilterChallengeCategoryType>(categories[0]?.category) // 영어
-
-  console.log('카테고리 : ', category)
 
   const [input, setInput] = useState('') // 유저의 검색값
 
@@ -108,15 +102,25 @@ export const GroupChallengeSections = ({ categories, className }: GroupChallenge
   } else {
     /** 검색값이 있는 경우 */
     contents = groupChallenges.map(challenge => {
-      const { id, title, leafReward, currentParticipantCount, endDate, startDate, remainingDay, thumbnailUrl } =
-        challenge
+      const {
+        id,
+        title,
+        category,
+        description,
+        leafReward,
+        currentParticipantCount,
+        endDate,
+        startDate,
+        remainingDay,
+        thumbnailUrl,
+      } = challenge
       const data: GroupChallenge = {
         id,
         name: title,
-        description: '더미 데이터', //TODO: 백엔드에서 description 데이터 추가해주면 넣기
+        description,
         startDate,
         endDate,
-        category, //TODO: 백엔드에서 description 데이터 추가해주면 넣기
+        category,
         currentParticipantCount,
         imageUrl: thumbnailUrl,
         leafReward,

--- a/src/features/member/components/member/profile/mypage/Mypage.tsx
+++ b/src/features/member/components/member/profile/mypage/Mypage.tsx
@@ -121,7 +121,6 @@ const Mypage = () => {
       },
       onError: err => {
         if (isMountedRef.current) {
-          console.log(err)
           setPollError('피드백 요청에 실패했어요.')
         }
       },

--- a/src/features/store/components/product/ProductCard.tsx
+++ b/src/features/store/components/product/ProductCard.tsx
@@ -130,6 +130,7 @@ const ThumbnailWrapper = styled.div`
   width: 100%;
   aspect-ratio: 1 / 1;
   border-radius: ${theme.radius.base};
+  overflow: hidden;
 `
 
 const Thumbnail = styled(Image)`
@@ -139,19 +140,18 @@ const Thumbnail = styled(Image)`
 `
 
 const TextContent = styled.div`
-  padding: 10px 0;
   display: flex;
   flex-direction: column;
 `
 
 const Title = styled.h3`
   margin: 12px 0 6px 0;
-  font-size: ${theme.fontSize.md};
+  font-size: ${theme.fontSize.xl};
   font-weight: ${theme.fontWeight.semiBold};
 `
 
 const Description = styled.p`
-  font-size: ${theme.fontSize.sm};
+  font-size: ${theme.fontSize.base};
   color: ${theme.colors.lfBlack.base};
   margin-top: 4px;
 `
@@ -174,14 +174,14 @@ const LeafIcon = styled(Image)`
 `
 
 const StockNotice = styled.div<{ isSoldOut: boolean }>`
-  font-size: ${theme.fontSize.xs};
+  font-size: ${theme.fontSize.sm};
   color: ${({ isSoldOut }) => (isSoldOut ? theme.colors.lfRed.base : theme.colors.lfBlack.base)};
 
   margin-top: 8px;
 `
 
 const BuyButton = styled.button`
-  margin-top: 12px;
+  margin-top: 8px;
   width: 100%;
   height: 44px;
   background: ${theme.colors.lfWhite.base};

--- a/src/features/store/components/product/ProductList.tsx
+++ b/src/features/store/components/product/ProductList.tsx
@@ -3,90 +3,13 @@
 import { ReactNode, useEffect, useRef, useState } from 'react'
 import styled from '@emotion/styled'
 
-import { Product } from '@features/store/api/get-products'
 import ApologizeContent from '@shared/components/apologize/apologize'
+import Loading from '@shared/components/loading'
 import { responsiveHorizontalPadding } from '@shared/styles/ResponsiveStyle'
 import { theme } from '@shared/styles/theme'
 
 import { useInfiniteProducts } from '../../hook/useInfiniteProducts'
 import ProductCard from './ProductCard'
-
-const dummyProducts: Product[] = [
-  {
-    id: 1,
-    title:
-      '친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 ',
-    description:
-      '언제 어디서나 사용 가능한 그린 텀블러 언제 어디서나 사용 가능한 그린 텀블러 언제 어디서나 사용 가능한 그린 텀블러 언제 어디서나 사용 가능한 그린 텀블러 ',
-    imageUrl: '/image/Main_1.png',
-    price: 4000,
-    stock: 0,
-  },
-  {
-    id: 2,
-    title: '대나무 칫솔',
-    description: '지구를 생각한 생분해 칫솔',
-    imageUrl: '/image/Main_1.png',
-    price: 3000,
-    stock: 5,
-  },
-  {
-    id: 3,
-    title: '대나무 칫솔',
-    description: '지구를 생각한 생분해 칫솔',
-    imageUrl: '/image/Main_1.png',
-    price: 3000,
-    stock: 5,
-  },
-  {
-    id: 4,
-    title: '대나무 칫솔',
-    description: '지구를 생각한 생분해 칫솔',
-    imageUrl: '/image/Main_1.png',
-    price: 3000,
-    stock: 5,
-  },
-  {
-    id: 5,
-    title: '대나무 칫솔',
-    description: '지구를 생각한 생분해 칫솔',
-    imageUrl: '/image/Main_1.png',
-    price: 3000,
-    stock: 5,
-  },
-  {
-    id: 6,
-    title: '대나무 칫솔',
-    description: '지구를 생각한 생분해 칫솔',
-    imageUrl: '/image/Main_1.png',
-    price: 3000,
-    stock: 5,
-  },
-  {
-    id: 7,
-    title: '대나무 칫솔',
-    description: '지구를 생각한 생분해 칫솔',
-    imageUrl: '/image/Main_1.png',
-    price: 3000,
-    stock: 5,
-  },
-  {
-    id: 8,
-    title: '대나무 칫솔',
-    description: '지구를 생각한 생분해 칫솔',
-    imageUrl: '/image/Main_1.png',
-    price: 3000,
-    stock: 5,
-  },
-  {
-    id: 9,
-    title: '대나무 칫솔',
-    description: '지구를 생각한 생분해 칫솔',
-    imageUrl: '/image/Main_1.png',
-    price: 3000,
-    stock: 5,
-  },
-]
 
 interface ProductListProps {
   className?: string
@@ -101,8 +24,8 @@ const ProductList = ({ className }: ProductListProps): ReactNode => {
   // 일반 상품 목록 조회
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteProducts(search)
 
-  // const products = data?.pages.flatMap(page => page?.data?.products || []) ?? []
-  const products: Product[] = dummyProducts
+  const products = data?.pages.flatMap(page => page?.data?.products || []) ?? []
+  // const products: Product[] = dummyProducts
 
   useEffect(() => {
     if (!hasNextPage || isFetchingNextPage) return
@@ -121,7 +44,8 @@ const ProductList = ({ className }: ProductListProps): ReactNode => {
   }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
   /** 이벤트 핸들러 */
-  const handleSearchSubmit = () => {
+  const handleSearchSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
     setSearch(input)
   }
 
@@ -131,10 +55,7 @@ const ProductList = ({ className }: ProductListProps): ReactNode => {
   const hasProducts: boolean = !(products.length === 0)
   if (!hasProducts) {
     contents = (
-      <StyledApologizeContent
-        title='준비된 일반 상품이 없습니다'
-        description='빠른 시일 내로 좋은 상품으로 찾아뵙겠습니다'
-      />
+      <ApologizeContent title='준비된 일반 상품이 없습니다' description='빠른 시일 내로 좋은 상품으로 찾아뵙겠습니다' />
     )
   } else {
     /** 일반 상품이 있는 경우 */
@@ -153,6 +74,7 @@ const ProductList = ({ className }: ProductListProps): ReactNode => {
           {products.map(product => (
             <ProductCard key={product.id} product={product} />
           ))}
+          {isFetchingNextPage && <StyledLoading />}
           {hasNextPage && <ObserverTrigger ref={observerRef} />}
         </ProductGrid>
       </>
@@ -180,7 +102,7 @@ const ContentWrapper = styled.div<{ hasProducts: boolean }>`
 const ProductGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 24px;
+  gap: 12px;
   margin-top: 8px;
 `
 
@@ -207,7 +129,84 @@ const ObserverTrigger = styled.div`
   height: 1px;
 `
 
-const StyledApologizeContent = styled(ApologizeContent)`
-  height: 100%;
+const StyledLoading = styled(Loading)`
+  grid-column: span 2;
 `
+
+// const dummyProducts: Product[] = [
+//   {
+//     id: 1,
+//     title:
+//       '친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 친환경 텀블러 ',
+//     description:
+//       '언제 어디서나 사용 가능한 그린 텀블러 언제 어디서나 사용 가능한 그린 텀블러 언제 어디서나 사용 가능한 그린 텀블러 언제 어디서나 사용 가능한 그린 텀블러 ',
+//     imageUrl: '/image/Main_1.png',
+//     price: 4000,
+//     stock: 0,
+//   },
+//   {
+//     id: 2,
+//     title: '대나무 칫솔',
+//     description: '지구를 생각한 생분해 칫솔',
+//     imageUrl: '/image/Main_1.png',
+//     price: 3000,
+//     stock: 5,
+//   },
+//   {
+//     id: 3,
+//     title: '대나무 칫솔',
+//     description: '지구를 생각한 생분해 칫솔',
+//     imageUrl: '/image/Main_1.png',
+//     price: 3000,
+//     stock: 5,
+//   },
+//   {
+//     id: 4,
+//     title: '대나무 칫솔',
+//     description: '지구를 생각한 생분해 칫솔',
+//     imageUrl: '/image/Main_1.png',
+//     price: 3000,
+//     stock: 5,
+//   },
+//   {
+//     id: 5,
+//     title: '대나무 칫솔',
+//     description: '지구를 생각한 생분해 칫솔',
+//     imageUrl: '/image/Main_1.png',
+//     price: 3000,
+//     stock: 5,
+//   },
+//   {
+//     id: 6,
+//     title: '대나무 칫솔',
+//     description: '지구를 생각한 생분해 칫솔',
+//     imageUrl: '/image/Main_1.png',
+//     price: 3000,
+//     stock: 5,
+//   },
+//   {
+//     id: 7,
+//     title: '대나무 칫솔',
+//     description: '지구를 생각한 생분해 칫솔',
+//     imageUrl: '/image/Main_1.png',
+//     price: 3000,
+//     stock: 5,
+//   },
+//   {
+//     id: 8,
+//     title: '대나무 칫솔',
+//     description: '지구를 생각한 생분해 칫솔',
+//     imageUrl: '/image/Main_1.png',
+//     price: 3000,
+//     stock: 5,
+//   },
+//   {
+//     id: 9,
+//     title: '대나무 칫솔',
+//     description: '지구를 생각한 생분해 칫솔',
+//     imageUrl: '/image/Main_1.png',
+//     price: 3000,
+//     stock: 5,
+//   },
+// ]
 // const dummyProducts: Product[] = []

--- a/src/features/store/hook/useInfiniteProducts.ts
+++ b/src/features/store/hook/useInfiniteProducts.ts
@@ -38,6 +38,5 @@ export const useInfiniteProducts = (input: string) => {
           }
         : undefined,
     ...QUERY_OPTIONS.STORE.PRODUCTS.LIST,
-    enabled: false, // TODO: API 추가하면서 삭제 필요
   })
 }

--- a/src/shared/components/modal/camera-modal/CameraModal.tsx
+++ b/src/shared/components/modal/camera-modal/CameraModal.tsx
@@ -422,6 +422,7 @@ const CloseButton = styled(LucideIcon)`
 const ShootButtonWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 8px;
 `
 

--- a/src/shared/constants/endpoint/endpoint.ts
+++ b/src/shared/constants/endpoint/endpoint.ts
@@ -182,7 +182,7 @@ const MEMBER_ENDPOINTS = {
       method: HttpMethod.DELETE,
       path: `/oauth/${provider}/token`,
     }),
-    RE_ISSUE: { method: HttpMethod.POST, path: '/auth/token/reissue' }, // 토큰 재발급
+    RE_ISSUE: { method: HttpMethod.POST, path: '/oauth/token/reissue' }, // 토큰 재발급
   },
 
   DUPLICATE_NICKNAME: { method: HttpMethod.GET, path: '/api/members/nickname' }, // 닉네임 중복 검사

--- a/src/shared/constants/route/route.ts
+++ b/src/shared/constants/route/route.ts
@@ -1,15 +1,22 @@
 import { ChallengeCategoryType } from '@entities/challenge/type'
 
+type URL = {
+  name: string
+  value: string
+  isProtected: false
+  hasBackButton: false
+}
+
 /**
- * FE라우트 엔드포인트 입니다
+ * FE 라우트
  */
-// 레이아웃 체크 필요 ✅  TODO: 뱃지 목록 페이지, 마이페이지, 프로필 수정
 const MAIN_URL = {
   INDEX: {
     name: '메인',
     value: '/',
     isProtected: false,
-  },
+    hasBackButton: false,
+  } as URL,
 }
 
 const MEMBER_URL = {
@@ -17,44 +24,54 @@ const MEMBER_URL = {
     name: '로그인',
     value: '/member/login',
     isProtected: false,
+    hasBackButton: true,
   },
   CALLBACK: {
     name: '소셜 로그인 콜백',
     value: (provider: string) => `/member/${provider}/callback`,
+    dynamicPath: '/member/[provider]/callback',
     isProtected: false,
+    hasBackButton: false,
   },
   SIGNUP: {
     name: '회원가입',
     value: '/member/signup',
     isProtected: false,
+    hasBackButton: true,
   },
   PROFILE: {
     MYPAGE: {
       name: '마이페이지',
       value: '/member/profile/mypage',
       isProtected: true,
+      hasBackButton: false,
     },
+
     MODIFY: {
       name: '프로필 수정',
       value: '/member/profile/modify',
       isProtected: true,
+      hasBackButton: true,
     },
     BADGE: {
       name: '뱃지 조회',
       value: '/member/profile/badge',
       isProtected: true,
+      hasBackButton: true,
     },
   },
   ALARM: {
     name: '알림 확인',
     value: '/member/alarm',
     isProtected: true,
+    hasBackButton: true,
   },
   CHALLENGES: {
     CREATED: {
       name: '생성한 챌린지',
       value: '/member/challenges',
       isProtected: true,
+      hasBackButton: true,
     },
   },
   STORE: {
@@ -62,6 +79,7 @@ const MEMBER_URL = {
       name: '나뭇잎 상점 구매 목록',
       value: '/member/store/list',
       isProtected: true,
+      hasBackButton: true,
     },
   },
 }
@@ -71,7 +89,9 @@ const CHALLENGE_URL = {
     DETAILS: {
       name: '개인 챌린지 상세',
       value: (personalId: number) => `/challenge/personal/${personalId}`,
+      dynamicPath: '/challenge/personal/[id]', // 👈 추가
       isProtected: false,
+      hasBackButton: true,
     },
   },
   GROUP: {
@@ -79,41 +99,54 @@ const CHALLENGE_URL = {
       name: '단체 챌린지 목록',
       value: (category?: ChallengeCategoryType) =>
         category ? `/challenge/group/list?category=${category}` : '/challenge/group/list',
+      dynamicPath: '/challenge/group/list',
       isProtected: false,
+      hasBackButton: true,
     },
     CREATE: {
       name: '단체 챌린지 생성',
       value: (category?: ChallengeCategoryType) =>
         category ? `/challenge/group/create?category=${category}` : `/challenge/group/create`,
+      dynamicPath: '/challenge/group/create',
       isProtected: true,
+      hasBackButton: true,
     },
     MODIFY: {
       name: '단체 챌린지 수정',
       value: (challengeId: number) => `/challenge/group/${challengeId}/modify`,
+      dynamicPath: '/challenge/group/[challengeId]/modify',
       isProtected: true,
+      hasBackButton: true,
     },
     DETAILS: {
       name: '단체 챌린지 상세',
       value: (challengeId: number) => `/challenge/group/${challengeId}`,
+      dynamicPath: '/challenge/group/[challengeId]',
       isProtected: false,
+      hasBackButton: true,
     },
     VERIFICATION: {
       LIST: {
         name: '이용자 인증 내역 목록',
         value: (challengeId: number) => `/challenge/group/${challengeId}/verification/list`,
+        dynamicPath: '/challenge/group/[challengeId]/verification/list',
         isProtected: false,
+        hasBackButton: true,
       },
       DETAILS: {
         name: '챌린지 인증 상세',
         value: (challengeId: number, verificationId: number) =>
           `/challenge/group/${challengeId}/verification/${verificationId}`,
+        dynamicPath: '/challenge/group/[challengeId]/verification/[verificationId]',
         isProtected: false,
+        hasBackButton: true,
       },
     },
     FEED: {
       name: '챌린지 인증 피드',
       value: `/challenge/group/feed`,
       isProtected: false,
+      hasBackButton: false,
     },
   },
   PARTICIPATE: {
@@ -121,11 +154,14 @@ const CHALLENGE_URL = {
       name: '참여중인 챌린지',
       value: `/challenge/participate`,
       isProtected: true,
+      hasBackButton: false,
     },
     DETAILS: {
       name: '챌린지 인증 현황',
       value: (participateId: number) => `/challenge/participate/${participateId}`,
+      dynamicPath: '/challenge/participate/[participateId]',
       isProtected: true,
+      hasBackButton: true,
     },
   },
 }
@@ -135,6 +171,7 @@ const STORE_URL = {
     name: '나뭇잎 상점',
     value: `/store`,
     isProtected: false,
+    hasBackButton: false,
   },
 }
 

--- a/src/shared/constants/route/route.ts
+++ b/src/shared/constants/route/route.ts
@@ -42,6 +42,7 @@ const MEMBER_URL = {
     BADGE: {
       name: '뱃지 조회',
       value: '/member/profile/badge',
+      isProtected: true,
     },
   },
   ALARM: {
@@ -89,6 +90,7 @@ const CHALLENGE_URL = {
     MODIFY: {
       name: '단체 챌린지 수정',
       value: (challengeId: number) => `/challenge/group/${challengeId}/modify`,
+      isProtected: true,
     },
     DETAILS: {
       name: '단체 챌린지 상세',

--- a/src/shared/lib/api/client-fetcher/client-fetcher.ts
+++ b/src/shared/lib/api/client-fetcher/client-fetcher.ts
@@ -14,7 +14,6 @@ export async function clientFetchRequest<T>(
   /** Request */
   const { method, path } = endpoint
   const url = new URL(BASE_URL + path)
-  console.log('✅클라이언트에서 보낸 엔드포인트 :', url)
 
   if (options.query) {
     Object.entries(options.query).forEach(([key, value]) => url.searchParams.append(key, String(value)))
@@ -49,6 +48,7 @@ export async function clientFetchRequest<T>(
     if ((response.status === 401 || response.status === 403) && !isRetry) {
       try {
         await refreshClientAccessToken()
+
         return clientFetchRequest<T>(endpoint, options, true) // 딱 한 번만 재시도
       } catch (refreshError) {
         const error: ErrorResponse = {

--- a/src/shared/lib/api/client-fetcher/client-reissue.ts
+++ b/src/shared/lib/api/client-fetcher/client-reissue.ts
@@ -10,10 +10,9 @@ export async function refreshClientAccessToken(): Promise<void> {
   if (isRefreshing) return refreshPromise ?? Promise.resolve()
 
   isRefreshing = true
-
   refreshPromise = (async () => {
     try {
-      const response = await fetch(`${BASE_URL}${ENDPOINTS.MEMBERS.AUTH.RE_ISSUE}`, {
+      const response = await fetch(`${BASE_URL}${ENDPOINTS.MEMBERS.AUTH.RE_ISSUE.path}`, {
         method: 'POST',
         credentials: 'include', // 재발급은 쿠키 포함
       })
@@ -21,11 +20,10 @@ export async function refreshClientAccessToken(): Promise<void> {
       if (!response.ok) {
         throw new Error('Refresh failed')
       }
-
-      isRefreshing = false
     } catch (error) {
-      isRefreshing = false
       throw error // ❌ 핸들링 X (fetchRequest에서 처리)
+    } finally {
+      isRefreshing = false
     }
   })()
 

--- a/src/shared/lib/api/fetcher/fetcher.ts
+++ b/src/shared/lib/api/fetcher/fetcher.ts
@@ -7,15 +7,10 @@ import { serverFetchRequest } from '../server-fetcher'
 import { ApiResponse, OptionsType } from '../type'
 
 export const fetchRequest = async <T>(endpoint: EndpointType, options: OptionsType = {}): Promise<ApiResponse<T>> => {
-  console.log('🔴fetchRequest 엔드포인트 :', endpoint)
-
   // 서버 환경
   if (isServer) {
     // 서버 액션 fetch 호출 (쿠키 수동 포함)
-    console.log('서버 액션 코드 실행')
-
     return serverFetchRequest<T>(endpoint, options)
   }
-  console.log('클라이언트 액션 코드 실행')
   return clientFetchRequest<T>(endpoint, options)
 }

--- a/src/shared/lib/api/server-fetcher/server-fetcher.ts
+++ b/src/shared/lib/api/server-fetcher/server-fetcher.ts
@@ -15,14 +15,8 @@ export async function serverFetchRequest<T>(
   options: OptionsType = {},
   isRetry = false,
 ): Promise<ApiResponse<T>> {
-  console.log('🏴 서버 이장')
-
   const { method, path } = endpoint
-  console.log('base url: ', BASE_URL)
-
   const url = new URL(BASE_URL + path)
-
-  console.log('✅ 서버에서 보낸 엔드포인트 : ', url)
 
   if (options.query) {
     Object.entries(options.query).forEach(([key, value]) => url.searchParams.append(key, String(value)))

--- a/src/shared/lib/api/server-fetcher/server-reissue.ts
+++ b/src/shared/lib/api/server-fetcher/server-reissue.ts
@@ -25,7 +25,7 @@ export async function refreshServerAccessToken(): Promise<void> {
         .map(({ name, value }) => `${name}=${value}`)
         .join('; ')
 
-      const response = await fetch(`${BASE_URL}${ENDPOINTS.MEMBERS.AUTH.RE_ISSUE}`, {
+      const response = await fetch(`${BASE_URL}${ENDPOINTS.MEMBERS.AUTH.RE_ISSUE.path}`, {
         method: 'POST',
         headers: {
           Cookie: cookieHeader, // 재발급은 쿠키 포함


### PR DESCRIPTION
# 🍀 라우트에 따른 뒤로가기 버튼 추가

## 관련 이슈

Relates to #87
Closes #176

# 주요 변경사항

## 1. 라우트 파일 추가 필드
1. 뒤로가기 버튼이 필요한지 여부 필드 추가
2. 동적경로의 뒤로가기 여부 판단을 위해 키 추가

```typescript
DETAILS: {
      name: '챌린지 인증 현황',
      value: (participateId: number) => `/challenge/participate/${participateId}`,
      dynamicPath: '/challenge/participate/[participateId]',
      isProtected: true,
      hasBackButton: true,
    },
```

## 2. 헤더에서 뒤로가기 여부 판단
현재 경로를 기준으로 뒤로가기 여부를 판단하도록 하였습니다.

## 3. AuthGaurd (protected route 처리)
기존의 보호 경로가 동적 경로에 제대로 적용되지 않는 오류를 해결하였습니다.
-> dynamicPath 키로 해결하였습니다.


### PR간 오류 혹은 질문은 댓글로 남겨주세요!
