### PR TITLE
FE: PR (feat) 개인 챌린지 인증 제출 롱폴링 전역 수행 로직 구현  

### DIFF
--- a/src/app/(with-layout)/(with-header)/challenge/personal/[id]/ChallengePersonalDetails.tsx
+++ b/src/app/(with-layout)/(with-header)/challenge/personal/[id]/ChallengePersonalDetails.tsx
@@ -10,7 +10,6 @@ import { useQuery } from '@tanstack/react-query'
 import { ChallengeVerificationStatusType, DayType } from '@entities/challenge/type'
 import {
   getPersonalChallengeDetails,
-  PersonalChallengeDetail,
 } from '@features/challenge/api/get-personal-challenge-details'
 import {
   VerifyGroupChallengeResponse,
@@ -28,50 +27,14 @@ import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
 import { URL } from '@shared/constants/route/route'
 import { useCameraModalStore } from '@shared/context/modal/CameraModalStore'
 import { useConfirmModalStore } from '@shared/context/modal/ConfirmModalStore'
+import { usePollingStore } from '@shared/context/polling/PollingStore'
 import { ToastType } from '@shared/context/toast/type'
 import { useAuth } from '@shared/hooks/useAuth/useAuth'
 import { useToast } from '@shared/hooks/useToast/useToast'
 import LucideIcon from '@shared/lib/ui/LucideIcon'
 import { responsiveHorizontalPadding } from '@shared/styles/ResponsiveStyle'
 import { theme } from '@shared/styles/theme'
-import { TimeFormatString } from '@shared/types/date'
 import LeafIcon from '@public/icon/leaf.png'
-
-export const dummyPersonalChallengeDetail: PersonalChallengeDetail = {
-  id: 1,
-  title: '제로 웨이스트 실천하기',
-  description:
-    '하루 동안 일회용품 사용을 줄이고, 텀블러와 장바구니를 활용해보세요.\n실천하는 모습의 인증샷을 업로드해주세요!',
-  thumbnailUrl: '/icon/category_zero_waste.png',
-  dayOfWeek: 'MONDAY',
-  verificationStartTime: '08:00' as TimeFormatString,
-  verificationEndTime: '22:00' as TimeFormatString,
-  leafReward: 15,
-  exampleImages: [
-    {
-      id: 1,
-      imageUrl: '/icon/category_zero_waste.png',
-      type: 'SUCCESS',
-      description: '텀블러 사용 장면',
-      sequenceNumber: 1,
-    },
-    {
-      id: 2,
-      imageUrl: '/icon/category_zero_waste.png',
-      type: 'SUCCESS',
-      description: '장바구니 사용 장면',
-      sequenceNumber: 2,
-    },
-    {
-      id: 3,
-      imageUrl: '/icon/category_zero_waste.png',
-      type: 'FAILURE',
-      description: '일회용 컵을 사용한 장면',
-      sequenceNumber: 3,
-    },
-  ],
-  status: 'NOT_SUBMITTED',
-}
 
 type WarningType = {
   isWarning: boolean
@@ -97,6 +60,8 @@ const ChallengePersonalDetails = ({ challengeId, className }: ChallengePersonalD
   const { open: openCameraModal } = useCameraModalStore()
   const { isLoggedIn } = useAuth()
   const { openConfirmModal } = useConfirmModalStore()
+
+  const { addChallengeId } = usePollingStore()
 
   /** 개인 챌린지 상세 가져오기 */
   const { data, isLoading } = useQuery({
@@ -136,7 +101,11 @@ const ChallengePersonalDetails = ({ challengeId, className }: ChallengePersonalD
   /** 제출 버튼 비활성화 여부 */
   const isButtonDisabled: boolean = status !== 'NOT_SUBMITTED'
   const getSubmitButtonLabel = (status: ChallengeVerificationStatusType): string => {
-    if (status === 'PENDING_APPROVAL') return '인증여부 판단 중'
+    if (status === 'PENDING_APPROVAL') {
+      // TODO: 인증이 올바르게 AI펍섭에 들어가지 않은 경우 핸들링 필요 (협업)
+      // addChallengeId(challengeId)
+      return '인증여부 판단 중'
+    }
     if (status === 'SUCCESS' || status === 'FAILURE' || status === 'DONE') return '참여 완료'
     return '참여하기'
   }
@@ -216,6 +185,7 @@ const ChallengePersonalDetails = ({ challengeId, className }: ChallengePersonalD
       },
       {
         onSuccess: () => {
+          addChallengeId(challengeId) // 인증 결과 롱폴링 시작
           openToast(ToastType.Success, `제출 성공!\nAI 판독 결과를 기다려주세요`) // 성공 메시지
         },
       },
@@ -425,6 +395,42 @@ const Warning = styled.div<{ isWarning: boolean }>`
 `
 
 // export const dummyPersonalChallengeDetail: PersonalChallengeDetail = {
+//   id: 1,
+//   title: '제로 웨이스트 실천하기',
+//   description:
+//     '하루 동안 일회용품 사용을 줄이고, 텀블러와 장바구니를 활용해보세요.\n실천하는 모습의 인증샷을 업로드해주세요!',
+//   thumbnailUrl: '/icon/category_zero_waste.png',
+//   dayOfWeek: 'MONDAY',
+//   verificationStartTime: '08:00' as TimeFormatString,
+//   verificationEndTime: '22:00' as TimeFormatString,
+//   leafReward: 15,
+//   exampleImages: [
+//     {
+//       id: 1,
+//       imageUrl: '/icon/category_zero_waste.png',
+//       type: 'SUCCESS',
+//       description: '텀블러 사용 장면',
+//       sequenceNumber: 1,
+//     },
+//     {
+//       id: 2,
+//       imageUrl: '/icon/category_zero_waste.png',
+//       type: 'SUCCESS',
+//       description: '장바구니 사용 장면',
+//       sequenceNumber: 2,
+//     },
+//     {
+//       id: 3,
+//       imageUrl: '/icon/category_zero_waste.png',
+//       type: 'FAILURE',
+//       description: '일회용 컵을 사용한 장면',
+//       sequenceNumber: 3,
+//     },
+//   ],
+//   status: 'NOT_SUBMITTED',
+// }
+
+// const dummyPersonalChallengeDetail: PersonalChallengeDetail = {
 //   id: 1,
 //   title: '제로 웨이스트 실천하기',
 //   description:

--- a/src/app/(with-layout)/layout.tsx
+++ b/src/app/(with-layout)/layout.tsx
@@ -1,6 +1,7 @@
 import ModalProvider from '@shared/components/modal/ModalProvider'
 import Toast from '@shared/components/toast/Toast'
 import AuthGuard from '@shared/config/providers/AuthGaurd'
+import PollingWatcher from '@shared/config/providers/PollingWatcher'
 import LayoutWrapper from '@shared/styles/LayoutWrapper'
 
 const RootLayout = ({
@@ -11,6 +12,7 @@ const RootLayout = ({
   return (
     <AuthGuard>
       <LayoutWrapper>
+        <PollingWatcher /> {/* 롱폴링 상태 조회  */}
         {children}
         <Toast />
         <ModalProvider />

--- a/src/features/challenge/api/get-personal-challenge-details.ts
+++ b/src/features/challenge/api/get-personal-challenge-details.ts
@@ -26,6 +26,7 @@ export type PersonalChallengeDetail = {
 
 type PersonalChallengeDetailResponse = PersonalChallengeDetail
 
+/** 개인 챌린지 인증 결과 */
 export const getPersonalChallengeDetails = (id: number) => {
   return fetchRequest<PersonalChallengeDetailResponse>(ENDPOINTS.CHALLENGE.PERSONAL.DETAILS(id))
 }

--- a/src/features/challenge/api/verify-personal-challenge.ts
+++ b/src/features/challenge/api/verify-personal-challenge.ts
@@ -1,3 +1,4 @@
+import { ChallengeVerificationStatusType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api'
 import { ISOFormatString } from '@shared/types/date'
@@ -22,4 +23,15 @@ export const VerifyGroupChallenge = ({ challengeId, body }: VerifyVariables) => 
   return fetchRequest<VerifyGroupChallengeResponse>(ENDPOINTS.CHALLENGE.PERSONAL.VERIFY(challengeId), {
     body,
   })
+}
+
+export type PersonalChallengeVerificationResultResponse = {
+  status: ChallengeVerificationStatusType
+}
+
+/** 개인 챌린지 인증 결과 조회 (롱폴링) */
+export const PersonalChallengeVerificationResult = (personalChallengeId: number) => {
+  return fetchRequest<PersonalChallengeVerificationResultResponse>(
+    ENDPOINTS.CHALLENGE.PERSONAL.VERIFICATION_RESULT(personalChallengeId),
+  )
 }

--- a/src/features/challenge/hook/use-personal-verification-result.ts
+++ b/src/features/challenge/hook/use-personal-verification-result.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
+import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
+
+import { PersonalChallengeVerificationResult } from '../api/verify-personal-challenge'
+
+type PollingQueryOptions = {
+  enabled: boolean // 실행 가능 여부 (불필요한 요청을 막기 위해)
+}
+
+export const usePersonalChallengeVerificationResult = (
+  challengeId: number,
+  { enabled = false }: PollingQueryOptions,
+) => {
+  return useQuery({
+    queryKey: QUERY_KEYS.CHALLENGE.PERSONAL.VERIFICATION.RESULT(challengeId),
+    queryFn: () => PersonalChallengeVerificationResult(challengeId),
+    ...QUERY_OPTIONS.CHALLENGE.PERSONAL.VERIFICATION_RESULT,
+    enabled,
+    refetchInterval: 5000, // 5초
+    refetchIntervalInBackground: true,
+  })
+}

--- a/src/shared/components/modal/camera-modal/CameraModal.tsx
+++ b/src/shared/components/modal/camera-modal/CameraModal.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import Image from 'next/image'
+
 import { useEffect, useRef, useState } from 'react'
 import styled from '@emotion/styled'
 
@@ -233,7 +235,11 @@ const CameraModal = () => {
           {title}
         </Header>
         <CameraWrapper>
-          {previewUrl ? <ImagePreview src={previewUrl} /> : <CameraView ref={videoRef} autoPlay playsInline />}
+          {previewUrl ? (
+            <ImagePreview src={previewUrl} alt='촬영된 이미지' fill />
+          ) : (
+            <CameraView ref={videoRef} autoPlay playsInline />
+          )}
         </CameraWrapper>
         <canvas ref={canvasRef} style={{ display: 'none' }} />
 
@@ -317,13 +323,11 @@ const CameraWrapper = styled.div`
 
 const CameraView = styled.video`
   width: 100%;
-  aspect-ratio: 4/3;
   object-fit: cover;
 `
 
-const ImagePreview = styled.img`
-  width: 100%;
-  height: 100%;
+const ImagePreview = styled(Image)`
+  object-position: center;
   object-fit: cover;
 `
 

--- a/src/shared/config/providers/PollingWatcher.tsx
+++ b/src/shared/config/providers/PollingWatcher.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { usePersonalChallengeVerificationResult } from '@features/challenge/hook/use-personal-verification-result'
+import { usePollingStore } from '@shared/context/polling/PollingStore'
+import { ToastType } from '@shared/context/toast/type'
+import { useToast } from '@shared/hooks/useToast/useToast'
+
+enum PollingTarget {
+  PERSONAL_CHALLENGE_VERIFICATION_RESULT, // 개인 챌린지 인증 결과 조회
+  GROUP_CHALLENGE_VERIFICATION_RESULT, // 단체 챌린지 인증 결과 조회
+  FEEDBACK, // 개인 피드백
+  GROUP_CHALLENGE_CREATE, // 단체 챌린지 생성 검열
+}
+
+const PollingWatcher = () => {
+  const openToast = useToast()
+  const { personalChallengeIds, removeChallengeId } = usePollingStore()
+
+  /** 이벤트 핸들러 */
+  // TODO: type=단체 챌린지 인증 제출 핸들링
+  const handleOnCompleteChallenge = (type: PollingTarget, challengeId: number) => {
+    // #1. 챌린지 제거
+    removeChallengeId(challengeId)
+
+    // #2.토스트 띄우기
+    openToast(ToastType.Success, `인증 결과 도착!\n알림창을 확인해주세요`)
+  }
+  return (
+    <>
+      {personalChallengeIds.map(id => (
+        <PollingChallengeResult
+          key={id}
+          type={PollingTarget.PERSONAL_CHALLENGE_VERIFICATION_RESULT}
+          challengeId={id}
+          onComplete={handleOnCompleteChallenge}
+        />
+      ))}
+    </>
+  )
+}
+
+interface PollingChallengeResultProps {
+  challengeId: number
+  type: PollingTarget
+  onComplete: (type: PollingTarget, challengeId: number) => void
+}
+const PollingChallengeResult = ({ type, challengeId, onComplete }: PollingChallengeResultProps) => {
+  const { data } = usePersonalChallengeVerificationResult(challengeId, {
+    enabled: true,
+  })
+
+  if (data) {
+    const { data: result } = data
+    // 인증 결과가 도착한 경우
+    if (result.status === 'SUCCESS' || result.status === 'FAILURE') {
+      onComplete(PollingTarget.PERSONAL_CHALLENGE_VERIFICATION_RESULT, challengeId)
+    }
+  }
+
+  return null
+}
+
+export default PollingWatcher

--- a/src/shared/config/providers/QueryClientProvider.tsx
+++ b/src/shared/config/providers/QueryClientProvider.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { ReactNode } from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 import { getQueryClient } from '../tanstack-query/queryClient'
 
@@ -12,7 +13,7 @@ export default function TanstackQueryProvider({ children }: Props) {
   return (
     <QueryClientProvider client={getQueryClient()}>
       {children}
-      {/* <ReactQueryDevtools /> */}
+      <ReactQueryDevtools />
     </QueryClientProvider>
   )
 }

--- a/src/shared/context/polling/PollingStore.ts
+++ b/src/shared/context/polling/PollingStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+type PollingState = {
+  personalChallengeIds: number[]
+  addChallengeId: (id: number) => void
+  removeChallengeId: (id: number) => void
+}
+
+export const usePollingStore = create<PollingState>()(
+  persist(
+    (set, get) => ({
+      personalChallengeIds: [],
+      addChallengeId: (id: number) => {
+        const current = get().personalChallengeIds
+        if (!current.includes(id)) {
+          set({ personalChallengeIds: [...current, id] })
+        }
+      },
+      removeChallengeId: (id: number) => {
+        const filtered = get().personalChallengeIds.filter(chId => chId !== id)
+        set({ personalChallengeIds: filtered })
+      },
+    }),
+    {
+      name: 'polling-store',
+      partialize: state => ({ personalChallengeIds: state.personalChallengeIds }), // 필요한 키만 저장
+    },
+  ),
+)


### PR DESCRIPTION
# 요약

> 작업내용을 간략히 작성합니다.

개인 챌린지 인증을 제출한 경우, 롱폴링으로 인증 결과를 수령하며 / 전역에서 수행하여 어디서든지 결과를 받아볼 수 있도록 구현합니다.

# 변경사항

> 변경사항을 항목별로 자세히 작성합니다.

## 1. API 추가

## 2. 전역 상수를 활용하여, 롱폴링 필요 id를 로컬호스트에 저장 

## 3. 롱폴리 감시 컴포넌트 (PollingWatcher.tsx) 추가
- 전역 레이아웃에서, 로컬 스토리지에 담긴 id들을 토대로, 롱폴링을 요청하는 감시 컴포넌트를 만들었습니다

### PR간 오류 혹은 질문은 댓글로 남겨주세요!

## 관련 이슈

Relates to #232 
Closes #236 
