### PR TITLE
FE : PR (feat) UTC 시간을 받아, KST로 변환

### DIFF
--- a/src/features/challenge/api/create-group-challenge.ts
+++ b/src/features/challenge/api/create-group-challenge.ts
@@ -1,7 +1,7 @@
 import { ChallengeCategoryType, ChallengeVerificationResultType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api'
-import { DateFormatString, TimeFormatString } from '@shared/types/date'
+import { ISOFormatString, TimeFormatString } from '@shared/types/date'
 
 export type CreateChallengeResponse = {
   id: number
@@ -20,8 +20,8 @@ export type CreateChallengeBody = {
   category: ChallengeCategoryType
   maxParticipantCount: number
   thumbnailImageUrl: string
-  startDate: DateFormatString
-  endDate: DateFormatString
+  startDate: ISOFormatString
+  endDate: ISOFormatString
   verificationStartTime: TimeFormatString
   verificationEndTime: TimeFormatString
   exampleImages: ExampleImage[]

--- a/src/features/challenge/api/get-group-challenge-details.ts
+++ b/src/features/challenge/api/get-group-challenge-details.ts
@@ -1,5 +1,3 @@
-// @features/challenge/api/getGroupChallengeDetails.ts
-
 import {
   ChallengeCategoryType,
   ChallengeVerificationResultType,
@@ -7,7 +5,7 @@ import {
 } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api'
-import { DateFormatString, TimeFormatString } from '@shared/types/date'
+import { ISOFormatString, TimeFormatString } from '@shared/types/date'
 
 export type GroupChallengeDetail = {
   id: number
@@ -15,8 +13,8 @@ export type GroupChallengeDetail = {
   category: ChallengeCategoryType
   title: string
   description: string
-  startDate: DateFormatString
-  endDate: DateFormatString
+  startDate: ISOFormatString
+  endDate: ISOFormatString
   verificationStartTime: TimeFormatString
   verificationEndTime: TimeFormatString
   leafReward: number

--- a/src/features/challenge/api/get-group-challenge-list.ts
+++ b/src/features/challenge/api/get-group-challenge-list.ts
@@ -2,7 +2,7 @@ import { ChallengeCategoryType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api'
 import { InfiniteScrollResponse } from '@shared/types/api'
-import { DateFormatString } from '@shared/types/date'
+import { ISOFormatString } from '@shared/types/date'
 
 /**
  * 요청 파라미터 타입
@@ -25,8 +25,8 @@ export interface GroupChallengeItem {
   description: string
   thumbnailUrl: string
   leafReward: number
-  startDate: DateFormatString
-  endDate: DateFormatString
+  startDate: ISOFormatString
+  endDate: ISOFormatString
   remainingDay: number
   currentParticipantCount: number
 }

--- a/src/features/challenge/api/get-group-challenge-rules.ts
+++ b/src/features/challenge/api/get-group-challenge-rules.ts
@@ -1,7 +1,7 @@
 import { ChallengeVerificationResultType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api'
-import { DateFormatString, TimeFormatString } from '@shared/types/date'
+import { ISOFormatString, TimeFormatString } from '@shared/types/date'
 
 type ExampleImage = {
   id: number
@@ -13,8 +13,8 @@ type ExampleImage = {
 
 export type GroupChallengeRulesListResponse = {
   certificationPeriod: {
-    startDate: DateFormatString
-    endDate: DateFormatString
+    startDate: ISOFormatString
+    endDate: ISOFormatString
     startTime: TimeFormatString
     endTime: TimeFormatString
   }

--- a/src/features/challenge/api/get-personal-challenge-details.ts
+++ b/src/features/challenge/api/get-personal-challenge-details.ts
@@ -1,5 +1,3 @@
-// @features/challenge/api/getGroupChallengeDetails.ts
-
 import { ChallengeVerificationResultType, ChallengeVerificationStatusType, DayType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api'

--- a/src/features/challenge/api/modify-group-challenge.ts
+++ b/src/features/challenge/api/modify-group-challenge.ts
@@ -1,7 +1,7 @@
 import { ChallengeCategoryType, ChallengeVerificationResultType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api'
-import { DateFormatString, TimeFormatString } from '@shared/types/date'
+import { ISOFormatString, TimeFormatString } from '@shared/types/date'
 
 export type KeepImage = {
   id: number
@@ -20,8 +20,8 @@ export type ModifyChallengeBody = {
   category: ChallengeCategoryType // enum 값으로 관리
   maxParticipantCount: number
   thumbnailImageUrl: string
-  startDate: DateFormatString
-  endDate: DateFormatString
+  startDate: ISOFormatString
+  endDate: ISOFormatString
   verificationStartTime: TimeFormatString
   verificationEndTime: TimeFormatString
   exampleImages: {

--- a/src/features/challenge/api/participate/group-participant.ts
+++ b/src/features/challenge/api/participate/group-participant.ts
@@ -2,6 +2,7 @@ import { FeedVerificationStatusType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api'
 import { InfiniteScrollResponse } from '@shared/types/api'
+import { ISOFormatString } from '@shared/types/date'
 
 export type ChallengeStatus = 'not_started' | 'ongoing' | 'completed'
 
@@ -20,8 +21,8 @@ export type ParticipantChallengeItem = {
   id: number
   title: string
   thumbnailUrl: string
-  startDate: string
-  endDate: string
+  startDate: ISOFormatString
+  endDate: ISOFormatString
   achievement: {
     success: number
     total: number

--- a/src/features/challenge/components/challenge/group/GroupChallengeFormPage.tsx
+++ b/src/features/challenge/components/challenge/group/GroupChallengeFormPage.tsx
@@ -30,7 +30,7 @@ import { MUTATION_KEYS } from '@shared/config/tanstack-query/mutation-keys'
 import { URL } from '@shared/constants/route/route'
 import { ToastType } from '@shared/context/toast/type'
 import { useToast } from '@shared/hooks/useToast/useToast'
-import { formatDateToDateFormatString } from '@shared/lib/date/utils'
+import { getKstMidnightToUtcISOString } from '@shared/lib/date/utils'
 import { responsiveHorizontalPadding } from '@shared/styles/ResponsiveStyle'
 import { theme } from '@shared/styles/theme'
 import { TimeFormatString } from '@shared/types/date'
@@ -143,12 +143,14 @@ const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: 
       category: convertLanguage(CHALLENGE_CATEGORY_PAIRS, 'kor', 'eng')(category) as ChallengeCategoryType,
       maxParticipantCount: maxParticipant,
       thumbnailImageUrl: thumbnailUrl,
-      startDate: formatDateToDateFormatString(startDate),
-      endDate: formatDateToDateFormatString(endDate),
+      startDate: getKstMidnightToUtcISOString(startDate),
+      endDate: getKstMidnightToUtcISOString(endDate),
       verificationStartTime: startTime as TimeFormatString,
       verificationEndTime: endTime as TimeFormatString,
       exampleImages: exampleImages,
     }
+    console.log('단체 챌린지 생성 바디: ', body)
+
     CreateChallengeMutate(
       { body },
       {
@@ -217,8 +219,8 @@ const GroupChallengeFormPage = ({ defaultValues, isEdit = false, challengeId }: 
       category: convertLanguage(CHALLENGE_CATEGORY_PAIRS, 'kor', 'eng')(category) as ChallengeCategoryType,
       maxParticipantCount: maxParticipant,
       thumbnailImageUrl: thumbnailUrl,
-      startDate: formatDateToDateFormatString(startDate),
-      endDate: formatDateToDateFormatString(endDate),
+      startDate: getKstMidnightToUtcISOString(startDate),
+      endDate: getKstMidnightToUtcISOString(endDate),
       verificationStartTime: startTime as TimeFormatString,
       verificationEndTime: endTime as TimeFormatString,
       exampleImages: {

--- a/src/features/challenge/components/challenge/group/details/ChallengeGroupDetails.tsx
+++ b/src/features/challenge/components/challenge/group/details/ChallengeGroupDetails.tsx
@@ -91,7 +91,7 @@ const ChallengeGroupDetails = ({ challengeId, className }: ChallengeGroupDetails
     status,
   } = challengeData
 
-  const totalDays = differenceInCalendarDays(endDate, startDate) + 1 /** 지속일 */
+  const totalDays = differenceInCalendarDays(new Date(endDate), new Date(startDate)) + 1 /** 지속일 */
   const verificationExampleImages: VerificationImageData[] = exampleImages.map(img => ({
     url: img.imageUrl,
     description: img.description,
@@ -122,28 +122,32 @@ const ChallengeGroupDetails = ({ challengeId, className }: ChallengeGroupDetails
       })
       return
     }
+
     const now = new Date()
+    const todayDateOnly = new Date(now.getFullYear(), now.getMonth(), now.getDate())
 
-    const startDateTime = new Date(`${startDate}T${verificationStartTime}`)
-    const endDateTime = new Date(`${endDate}T${verificationEndTime}`)
+    const localStartDate: Date = new Date(startDate)
+    const startDateOnly = new Date(localStartDate.getFullYear(), localStartDate.getMonth(), localStartDate.getDate())
 
-    /** #예외1 : 챌린지 기간이 아님 */
-    if (now < startDateTime || now > endDateTime) {
-      openToast(ToastType.Error, '챌린지 기간이 아닙니다!')
+    const localEndDate: Date = new Date(endDate)
+    const endDateOnly = new Date(localEndDate.getFullYear(), localEndDate.getMonth(), localEndDate.getDate())
+
+    // 1. 오늘이 챌린지 날짜 범위 내에 있는지 확인
+    if (todayDateOnly < startDateOnly || todayDateOnly > endDateOnly) {
+      openToast(ToastType.Error, '챌린지 진행 기간이 아닙니다!')
       return
     }
 
-    const startTime = verificationStartTime.split(':').map(Number)
-    const endTime = verificationEndTime.split(':').map(Number)
-    const currentTime = [now.getHours(), now.getMinutes()]
+    // 2. 현재 시간이 인증 가능 시간 범위 내에 있는지 확인
+    const nowMinutes = now.getHours() * 60 + now.getMinutes()
 
-    const currentMinutes = currentTime[0] * 60 + currentTime[1]
-    const startMinutes = startTime[0] * 60 + startTime[1]
-    const endMinutes = endTime[0] * 60 + endTime[1]
+    const [startHour, startMinute] = verificationStartTime.split(':').map(Number)
+    const [endHour, endMinute] = verificationEndTime.split(':').map(Number)
+    const startMinutes = startHour * 60 + startMinute
+    const endMinutes = endHour * 60 + endMinute
 
-    /** #예외2 : 기간은 맞으나, 시간이 아님 */
-    if (currentMinutes < startMinutes || currentMinutes > endMinutes) {
-      openToast(ToastType.Error, '참여 가능한 시간이 아닙니다')
+    if (nowMinutes < startMinutes || nowMinutes > endMinutes) {
+      openToast(ToastType.Error, '현재는 인증 가능한 시간이 아닙니다!')
       return
     }
 

--- a/src/features/challenge/components/challenge/group/list/GroupChallengeCard.tsx
+++ b/src/features/challenge/components/challenge/group/list/GroupChallengeCard.tsx
@@ -6,6 +6,7 @@ import styled from '@emotion/styled'
 
 import { URL } from '@shared/constants/route/route'
 import { theme } from '@shared/styles/theme'
+import { ISOFormatString } from '@shared/types/date'
 import LeafIcon from '@public/icon/leaf.png'
 
 interface GroupChallengeProps {
@@ -14,8 +15,8 @@ interface GroupChallengeProps {
     title: string
     thumbnailUrl: string
     leafReward: number
-    startDate: string
-    endDate: string
+    startDate: ISOFormatString
+    endDate: ISOFormatString
     remainingDay: number
     currentParticipantCount: number
   }

--- a/src/features/challenge/components/challenge/participate/GroupVerificationPage.tsx
+++ b/src/features/challenge/components/challenge/participate/GroupVerificationPage.tsx
@@ -24,7 +24,6 @@ export default function GroupVerificationPage({ participateId }: { participateId
 
   const challengeId = participateId
 
-  //tanstack query
   const {
     data: verificationData,
     isPending,
@@ -61,8 +60,17 @@ export default function GroupVerificationPage({ participateId }: { participateId
           },
         })
       },
-      /* 3. hasDescription */ true,
-      //   /* 4. type */ 'SUCCESS',
+      // #3. 이미지에 대한 설명을 받을지 여부
+      true,
+
+      // #4. 어떤 인증인지 여부
+      'DONE' /** TODO: SUCCESS / FAILURE가 아닌걸로 설정하기 위해 더미값 넣어둠, 구별 필요 */,
+
+      // #5. 챌린지 정보 명시
+      {
+        id: challengeId,
+        type: 'GROUP',
+      },
     )
   }
   return (

--- a/src/features/challenge/components/common/group-challenge-card/GroupChallengeCard.tsx
+++ b/src/features/challenge/components/common/group-challenge-card/GroupChallengeCard.tsx
@@ -18,14 +18,14 @@ import { ToastType } from '@shared/context/toast/type'
 import { useAuth } from '@shared/hooks/useAuth/useAuth'
 import { useToast } from '@shared/hooks/useToast/useToast'
 import LucideIcon from '@shared/lib/ui/LucideIcon'
-import { DateFormatString } from '@shared/types/date'
+import { ISOFormatString } from '@shared/types/date'
 
 export type GroupChallenge = {
   id: number
   name: string
   description: string
-  startDate: DateFormatString // YYYY-mm-dd
-  endDate: DateFormatString
+  startDate: ISOFormatString
+  endDate: ISOFormatString
   imageUrl: string
   currentParticipantCount: number
   category: ChallengeCategoryType
@@ -140,7 +140,7 @@ export const GroupChallengeCard = ({
     })
   }
 
-  const { id, imageUrl, name, description, currentParticipantCount, category, endDate, startDate, leafReward } = data
+  const { id, imageUrl, name, description, currentParticipantCount, category, leafReward } = data
   const KOR_category = convertLanguage(CHALLENGE_CATEGORY_PAIRS, 'eng', 'kor')(category) // 카테고리를 한글로 변경
 
   return (

--- a/src/features/challenge/components/member/alarm/MemberAlramList.tsx
+++ b/src/features/challenge/components/member/alarm/MemberAlramList.tsx
@@ -6,31 +6,9 @@ import styled from '@emotion/styled'
 import { useInfiniteMemberAlarmList } from '@features/member/hooks/useInfiniteMemberAlarmList'
 import { useMutationStore } from '@shared/config/tanstack-query/mutation-defaults'
 import { MUTATION_KEYS } from '@shared/config/tanstack-query/mutation-keys'
+import { getTimeDiff } from '@shared/lib/date/utils'
 import { responsiveHorizontalPadding } from '@shared/styles/ResponsiveStyle'
 import { theme } from '@shared/styles/theme'
-import { ISOFormatString } from '@shared/types/date'
-
-export const toISOFormatString = (date: Date): ISOFormatString => date.toISOString() as ISOFormatString
-
-export function formatRelativeTime(target: Date): string {
-  const now = new Date()
-  const diffMs = now.getTime() - target.getTime()
-
-  const minutes = Math.floor(diffMs / (1000 * 60))
-  if (minutes < 60) return `${minutes}분 전`
-
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}시간 전`
-
-  const days = Math.floor(hours / 24)
-  if (days < 7) return `${days}일 전`
-
-  return target.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
-}
 
 const MemberAlarmList = () => {
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } = useInfiniteMemberAlarmList()
@@ -68,7 +46,7 @@ const MemberAlarmList = () => {
               <Content>
                 <AlarmTitle>{alarm.title}</AlarmTitle>
                 <AlarmDesc>{alarm.content}</AlarmDesc>
-                <CreatedAt>{formatRelativeTime(new Date(alarm.createdAt))}</CreatedAt>
+                <CreatedAt>{getTimeDiff(alarm.createdAt)}</CreatedAt>
               </Content>
             </AlarmCard>
           ))

--- a/src/features/member/api/challenge/get-group-creations.ts
+++ b/src/features/member/api/challenge/get-group-creations.ts
@@ -2,7 +2,7 @@ import { ChallengeCategoryType } from '@entities/challenge/type'
 import { ENDPOINTS } from '@shared/constants/endpoint/endpoint'
 import { fetchRequest } from '@shared/lib/api'
 import { InfiniteScrollResponse } from '@shared/types/api'
-import { DateFormatString, ISOFormatString } from '@shared/types/date'
+import { ISOFormatString } from '@shared/types/date'
 
 interface MemberGroupChallengeCreationsParams {
   cursorId?: number
@@ -13,8 +13,8 @@ export type GroupChallengeResponse = {
   id: number
   name: string
   description: string
-  startDate: DateFormatString // YYYY-mm-dd
-  endDate: DateFormatString
+  startDate: ISOFormatString
+  endDate: ISOFormatString
   imageUrl: string
   currentParticipantCount: number
   category: ChallengeCategoryType

--- a/src/shared/components/modal/camera-modal/CameraModal.tsx
+++ b/src/shared/components/modal/camera-modal/CameraModal.tsx
@@ -25,6 +25,7 @@ type FacingMode = 'user' | 'environment'
 const CameraModal = () => {
   const openToast = useToast()
   const { isOpen, title, challengeData, hasDescription, onComplete, close, status } = useCameraModalStore()
+
   const { uploadFile, loading: uploading, error: uploadError } = useImageUpload()
 
   const videoRef = useRef<HTMLVideoElement>(null)

--- a/src/shared/components/modal/camera-modal/VerificationGuideModal.tsx
+++ b/src/shared/components/modal/camera-modal/VerificationGuideModal.tsx
@@ -21,6 +21,7 @@ import { QUERY_OPTIONS } from '@shared/config/tanstack-query/query-defaults'
 import { QUERY_KEYS } from '@shared/config/tanstack-query/query-keys'
 import { ChallengeDataType } from '@shared/context/modal/CameraModalStore'
 import { ApiResponse } from '@shared/lib/api/type'
+import { extractDateFromISOInKST } from '@shared/lib/date/utils'
 import LucideIcon from '@shared/lib/ui/LucideIcon'
 import { theme } from '@shared/styles/theme'
 
@@ -67,7 +68,7 @@ const VerificationGuideModal = ({ isOpen, challengeData, onClose }: Verification
     let periodText = ''
     if (type === 'GROUP') {
       const groupPeriod = certificationPeriod as GroupChallengeRulesListResponse['certificationPeriod']
-      periodText = `${groupPeriod.startDate.slice(2)} ~ ${groupPeriod.endDate.slice(2)}`
+      periodText = `${extractDateFromISOInKST(groupPeriod.startDate).slice(2, -1)} ~ ${extractDateFromISOInKST(groupPeriod.endDate).slice(2, -1)}`
     } else {
       const personalPeriod = certificationPeriod as PersonalChallengeRulesListResponse['certificationPeriod']
       periodText = convertLanguage(DAY_PAIRS, 'eng', 'kor')(personalPeriod.dayOfWeek) as string

--- a/src/shared/constants/endpoint/endpoint.ts
+++ b/src/shared/constants/endpoint/endpoint.ts
@@ -53,15 +53,19 @@ const CHALLENGE_ENDPOINTS = {
     CATEGORIES: { method: HttpMethod.GET, path: '/api/challenges/group/categories' },
 
     // 상세
+    // TODO: UTC 체크
     DETAILS: (challengeId: number) => ({
       method: HttpMethod.GET,
       path: `/api/challenges/group/${challengeId}`,
     }),
-    // 목록
+    //목록
+    // TODO: UTC 체크
     LIST: { method: HttpMethod.GET, path: '/api/challenges/group' },
     // 생성
+    // TODO: UTC 체크
     CREATE: { method: HttpMethod.POST, path: '/api/challenges/group' },
     // 수정
+    // TODO: UTC 체크
     MODIFY: (challengeId: number) => ({
       method: HttpMethod.PATCH,
       path: `/api/challenges/group/${challengeId}`,
@@ -74,6 +78,7 @@ const CHALLENGE_ENDPOINTS = {
     }),
 
     // 인증 규약 조회
+    // TODO: UTC 체크
     RULES: (challengeId: number) => ({
       method: HttpMethod.GET,
       path: `/api/challenges/group/${challengeId}/rules`,
@@ -210,6 +215,7 @@ const MEMBER_ENDPOINTS = {
 
   // 알림
   NOTIFICATION: {
+    // TODO: UTC 체크
     LIST: { method: HttpMethod.GET, path: '/api/members/notifications' }, // 알림 조회
     READ: { method: HttpMethod.PATCH, path: '/api/members/notifications' }, // 알림 읽음 처리
   },
@@ -217,6 +223,7 @@ const MEMBER_ENDPOINTS = {
   // 나뭇잎 상점
   STORE: {
     ORDERS: {
+      // TODO: UTC 체크
       LIST: { method: HttpMethod.GET, path: '/api/members/products/list' }, // 구매 내역
     },
   },
@@ -224,11 +231,15 @@ const MEMBER_ENDPOINTS = {
   /** 챌린지 */
   CHALLENGE: {
     GROUP: {
+      // TODO: UTC 체크
       CREATIONS: { method: HttpMethod.GET, path: '/api/members/challenges/group/creations' }, // 생성한 챌린지
+
+      // 참여한 단체 챌린지 목록 조회
+      // TODO: UTC 체크
       PARTICIPATIONS: {
         method: HttpMethod.GET,
         path: '/api/members/challenges/group/participations',
-      }, // 참여한 단체 챌린지 목록 조회
+      },
 
       // 참여한 단체 챌린지 인증 내역을 일별로 조회
       VERIFICATIONS: (challengeId: number) => ({
@@ -256,6 +267,7 @@ const S3_ENDPOINTS = {
 const STORE_ENDPOINTS = {
   TIME_DEAL: {
     // 타임딜 상품 목록
+    // TODO: UTC 체크
     LIST: { method: HttpMethod.GET, path: '/api/store/products/timedeals' },
     // 타임딜 상품 주문
     ORDER: (dealId: number) => ({

--- a/src/shared/lib/date/utils.ts
+++ b/src/shared/lib/date/utils.ts
@@ -102,3 +102,23 @@ export const getTimeDiff = (dateString: ISOFormatString): string => {
 
   return `${diffYear}년 전`
 }
+
+/**
+ * KST 기준 자정을 UTC ISO 문자열로 변환
+ * @param date 로컬 Date 객체
+ * @returns ISO 문자열 (ex: "2025-06-17T00:00:00Z" ← 한국 기준 자정)
+ */
+export function getKstMidnightToUtcISOString(date: Date): ISOFormatString {
+  // 1. 연/월/일 추출
+  const year = date.getFullYear()
+  const month = date.getMonth()
+  const day = date.getDate()
+
+  // 2. 한국(KST) 자정 문자열 생성
+  const kstDateTimeString = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}T00:00:00+09:00`
+
+  // 3. Date 객체 생성 후 UTC로 변환
+  const utcDate = new Date(kstDateTimeString)
+
+  return utcDate.toISOString() as ISOFormatString
+}

--- a/src/shared/lib/date/utils.ts
+++ b/src/shared/lib/date/utils.ts
@@ -122,3 +122,14 @@ export function getKstMidnightToUtcISOString(date: Date): ISOFormatString {
 
   return utcDate.toISOString() as ISOFormatString
 }
+
+/**
+ * ISO 형식의 데이터에서 날짜만을 추출하는 방식
+ * @param iso ISO 형식 시간 (2025-06-17T00:00:00Z)
+ * @returns 날짜 (YYYY-MM-dd)
+ */
+export function extractDateFromISOInKST(iso: ISOFormatString): string {
+  return new Date(iso).toLocaleDateString('sv-SE', {
+    timeZone: 'Asia/Seoul',
+  })
+}

--- a/src/shared/lib/date/utils.ts
+++ b/src/shared/lib/date/utils.ts
@@ -76,6 +76,10 @@ export const getTimeDiff = (dateString: ISOFormatString): string => {
   const diffMonth = Math.floor(diffMs / (1000 * 60 * 60 * 24 * 7 * 30))
   const diffYear = Math.floor(diffMs / (1000 * 60 * 60 * 24 * 7 * 30 * 12))
 
+  // 1분 이내
+  if (diffMin < 1) {
+    return `방금`
+  }
   // 1시간 이내
   if (diffMin < 60) {
     return `${diffMin}분 전`
@@ -84,6 +88,11 @@ export const getTimeDiff = (dateString: ISOFormatString): string => {
   // 하루 이내
   if (diffHour < 24) {
     return `${diffHour}시간 전`
+  }
+
+  // 이틀 이내
+  if (diffDay < 2) {
+    return `어제`
   }
 
   // 일주일 이내


### PR DESCRIPTION
# 요약

> 작업내용을 간략히 작성합니다.

DB의 모든 시간을 UTC로 저장되어 있음에 따라, 프론트에서 시간을 `new Date()`로 파싱하는 코드를 수정합니다.

# 변경사항

> 변경사항을 항목별로 자세히 작성합니다.

DB의 모든 데이터가 ISO 8601 형식으로 변경됨에 따라,
기존의 startDate :  "YYYY-MM-dd" 형식으로 받아오던 데이터를 모두 startDate : "YYYY-mm-ddTHH:mm:ssZ" 형식으로 바꿔서 수령해야 합니다.

## 수정된 API 목록

### 요청

**챌린지**

- 단체 챌린지 생성 (POST)
- 단체 챌린지 수정 (PATCH)

## 응답

**챌린지**

- 단체 챌린지 목록 조회 (검색 포함)
- 단체 챌린지 상세 조회
- 단체 챌린지 인증 규약 조회

**회원**

- 생성한 단체 챌린지 목록 조회
- 상품 구매 내역 조회
- 참여한 단체 챌린지 목록 조회 (인증 페이지)
- 알림 조회

**상점**

- 타임딜 상품 목록 조회

## 추가 변경사항

### 단체 챌린지 인증 규약 조회
단체 챌린지 인증시에, 사진을 촬영하는 `CameraModal`을 열때, 인증 규약이 있다고 명시하는 코드가 누락되어, 단체 챌린지 사진 촬영시에 규약이 보이지 않고 있었습니다.

아래와 같이 수정하여 인증 규약 탭이 보이도록 하였습니다.

[기존]
```tsx
  const handleCapture = () => {
    openCameraModal(
      // 1. 제목
      `${verifications.title} 인증`,
      // 2. 완료 콜백: imageUrl → Blob → FormData → mutate
      async ({ imageUrl, description }) => {
        postMutation.mutate({
          challengeId,
          body: {
            imageUrl,
            content: description,
          },
        })
      },
      /* 3. hasDescription */ true,
      //   /* 4. type */ 'SUCCESS',
    )
  }
```

[변경]
```tsx
const handleCapture = () => {
    openCameraModal(
      // 1. 제목
      `${verifications.title} 인증`,
      // 2. 완료 콜백: imageUrl → Blob → FormData → mutate
      async ({ imageUrl, description }) => {
        postMutation.mutate({
          challengeId,
          body: {
            imageUrl,
            content: description,
          },
        })
      },
      // #3. 이미지에 대한 설명을 받을지 여부
      true,

      // #4. 어떤 인증인지 여부
      'DONE' /** TODO: SUCCESS / FAILURE가 아닌걸로 설정하기 위해 더미값 넣어둠, 구별 필요 */,

      // #5. 챌린지 정보 명시 ✅ <- 해당 정보가 포함되어야 인증 규약 탭을 보여주며, 데이터를 받아옵니다.
      {
        id: challengeId,
        type: 'GROUP',
      },
    )
```



## 관련 이슈

Closes #246
