### PR TITLE
feat: tag 전처리 중 v 삭제되는 현상 수정

### DIFF
--- a/.github/workflows/fe-cicd.yml
+++ b/.github/workflows/fe-cicd.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Extract tag name
         id: tag
         run: |
-          TAG_NAME="${GITHUB_REF#refs/tags/v}"
+          TAG_NAME="${GITHUB_REF#refs/tags}"
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
 
       - name: Deploy to Dev


### PR DESCRIPTION
# 요약

> tag 이름 중 v가 사라지는 현상 수정

# 변경사항

> tag 규칙 상 . 같은 특수기호가 앞에 오면 안되는데, tag_name 전처리 중 'v'가 사라져 오류가 발생하는 현상을 발견해 수정함.

## 1.

## 관련 이슈

Relates to #none
Closes #none
