### PR TITLE
feat: 점검중 페이지 배포환경 파일 체킹으로 변경

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,19 @@
-import fs from 'fs'
-
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function middleware(request: NextRequest) {
   const url = request.nextUrl
+  const hostname = request.headers.get('host') || ''
 
-  const maintenanceFilePath = '/app/.maintenance' // 점검중 유무 판단 (컨테이너 내 파일 경로)
-  const isUnderMaintenance = fs.existsSync(maintenanceFilePath)
+  const isProd = hostname.includes('leafresh.com') // prod 도메인만 적용
+
+  // 운영 환경에서만 점검 fetch
+  const isUnderMaintenance = isProd
+    ? await fetch('https://storage.googleapis.com/leafresh-prod-images/.maintenance/active', {
+        cache: 'no-store',
+      })
+        .then(res => res.ok)
+        .catch(() => false)
+    : false
 
   if (isUnderMaintenance && !url.pathname.startsWith('/maintenance')) {
     url.pathname = '/maintenance'

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,13 @@
+import fs from 'fs'
+
 import { NextRequest, NextResponse } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const url = request.nextUrl
 
-  // 점검 여부
-  const isUnderMaintenance: boolean = false
+  const maintenanceFilePath = '/app/.maintenance' // 점검중 유무 판단 (컨테이너 내 파일 경로)
+  const isUnderMaintenance = fs.existsSync(maintenanceFilePath)
 
-  // 점검중일 때, /maintenance로 rewrite
   if (isUnderMaintenance && !url.pathname.startsWith('/maintenance')) {
     url.pathname = '/maintenance'
     return NextResponse.rewrite(url)


### PR DESCRIPTION
# 요약

> 작업내용을 간략히 작성합니다.

미들웨어의 코드 직접 변경으로 진행되던 점검중 환경 체킹을 GCS 버킷의 특정 파일의 존재 유무를 통해 수행하도록 변경하였습니다.

단, 로컬 및 Prod 환경에서는 점검 유무를 판단하지 않아도 되므로, hostname을 토대로 점검중 페이지가 뜨지 않도록 하였습니다.


## 관련 이슈

Closes #266 
