### PR TITLE
PR:[feat] 환경 별 이미지 허용 pathname 할당

### DIFF
--- a/.github/workflows/fe-cicd.yml
+++ b/.github/workflows/fe-cicd.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           echo "${{  secrets.ENV_FE_ANALYTICS  }}" >> .env
           echo "${{  secrets.ENV_FE_TEST  }}" >> .env.test
-
+          echo "${{  secrets.ENV_FE_PROD  }}" >> .env.production
           pnpm run test
 
   integration-test:

--- a/.github/workflows/fe-cicd.yml
+++ b/.github/workflows/fe-cicd.yml
@@ -65,14 +65,14 @@ jobs:
       - name: Run Lint
         run: pnpm run lint
       - name: Run Unit Test
+        env:
+          NEXT_PUBLIC_RUNTIME: dev
+          NEXT_PUBLIC_GOOGLE_ANALYTICS: 'G-2BKG11WDXZ'
         run: |
           echo "${{  secrets.ENV_FE_ANALYTICS  }}" >> .env
           echo "${{  secrets.ENV_FE_TEST  }}" >> .env.test
           echo "${{  secrets.ENV_FE_PROD  }}" >> .env.production
           pnpm run test
-        env:
-          NEXT_PUBLIC_RUNTIME: dev
-          NEXT_PUBLIC_GOOGLE_ANALYTICS: 'G-2BKG11WDXZ'
 
   integration-test:
     name: Integration Test

--- a/.github/workflows/fe-cicd.yml
+++ b/.github/workflows/fe-cicd.yml
@@ -63,11 +63,12 @@ jobs:
           pnpm dedupe
           pnpm install
       - name: Run Lint
-        run: pnpm run lint
+        run: |
+          echo "${{  secrets.ENV_FE_ANALYTICS  }}" >> .env
+          echo "${{  secrets.ENV_FE_TEST  }}" >> .env.test
+          echo "${{  secrets.ENV_FE_PROD  }}" >> .env.production
+          pnpm run lint
       - name: Run Unit Test
-        env:
-          NEXT_PUBLIC_RUNTIME: dev
-          NEXT_PUBLIC_GOOGLE_ANALYTICS: 'G-2BKG11WDXZ'
         run: |
           echo "${{  secrets.ENV_FE_ANALYTICS  }}" >> .env
           echo "${{  secrets.ENV_FE_TEST  }}" >> .env.test

--- a/.github/workflows/fe-cicd.yml
+++ b/.github/workflows/fe-cicd.yml
@@ -70,6 +70,9 @@ jobs:
           echo "${{  secrets.ENV_FE_TEST  }}" >> .env.test
           echo "${{  secrets.ENV_FE_PROD  }}" >> .env.production
           pnpm run test
+        env:
+          NEXT_PUBLIC_RUNTIME: dev
+          NEXT_PUBLIC_GOOGLE_ANALYTICS: 'G-2BKG11WDXZ'
 
   integration-test:
     name: Integration Test

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,7 +31,7 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: 'http',
-        hostname: '*.kakaocdn.net',
+        hostname: '**.kakaocdn.net',
       },
     ],
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next'
 
 const runtimeEnv = process.env.NEXT_PUBLIC_RUNTIME
+console.log(runtimeEnv)
 
 let gcsHostname: string
 
@@ -14,7 +15,7 @@ switch (runtimeEnv) {
   case 'prod':
     gcsHostname = 'leafresh-prod-images'
   default:
-    throw new Error(`Unknown Image Route NEXT_PUBLIC_RUNTIME: ${runtimeEnv}`)
+    gcsHostname = 'leafresh-images'
 }
 
 const nextConfig: NextConfig = {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from 'next'
 
 const runtimeEnv = process.env.NEXT_PUBLIC_RUNTIME
-console.log(runtimeEnv)
 
 let gcsHostname: string
 
@@ -15,7 +14,7 @@ switch (runtimeEnv) {
   case 'prod':
     gcsHostname = 'leafresh-prod-images'
   default:
-    gcsHostname = 'leafresh-images'
+    throw new Error(`Unknown Image Route NEXT_PUBLIC_RUNTIME: ${runtimeEnv}`)
 }
 
 const nextConfig: NextConfig = {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,22 @@
 import type { NextConfig } from 'next'
 
+const runtimeEnv = process.env.NEXT_PUBLIC_RUNTIME
+
+let gcsHostname: string
+
+switch (runtimeEnv) {
+  case 'local':
+    gcsHostname = 'leafresh-images'
+    break
+  case 'dev':
+    gcsHostname = 'leafresh-images'
+    break
+  case 'prod':
+    gcsHostname = 'leafresh-prod-images'
+  default:
+    throw new Error(`Unknown Image Route NEXT_PUBLIC_RUNTIME: ${runtimeEnv}`)
+}
+
 const nextConfig: NextConfig = {
   /* config options here d*/
   compiler: {
@@ -10,7 +27,7 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'storage.googleapis.com', // 정확히 이 도메인이어야 함
-        pathname: '/leafresh-images/**', // 해당 경로 하위 모든 이미지 허용
+        pathname: `/${gcsHostname}/**`, // 해당 경로 하위 모든 이미지 허용
       },
       {
         protocol: 'http',

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,11 +31,7 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: 'http',
-        hostname: 'img1.kakaocdn.net',
-      },
-      {
-        protocol: 'http',
-        hostname: 't1.kakaocdn.net',
+        hostname: '*.kakaocdn.net',
       },
     ],
   },


### PR DESCRIPTION
# 요약

> 이미지 허용 url의 pathname을 동적으로 할당합니다.

# 변경사항


## 1. env RUNTIME 별 동적 할당

기존에 사용하던 환경변수에서 환경에 대한 정보를 담고 있는 비밀값 (NEXT_PUBLIC 기반 공개값), 각 개발환경의 허용 가능한 이미지 경로를 설정하였습니다.

```typescript
let gcsHostname: string

switch (runtimeEnv) {
  case 'local':
    gcsHostname = 'leafresh-images'
    break
  case 'dev':
    gcsHostname = 'leafresh-images'
    break
  case 'prod':
    gcsHostname = 'leafresh-prod-images'
  default:
    throw new Error(`Unknown Image Route NEXT_PUBLIC_RUNTIME: ${runtimeEnv}`)
}
```
```typescript
  {
    protocol: 'https',
    hostname: 'storage.googleapis.com', // 정확히 이 도메인이어야 함
    pathname: `/${gcsHostname}/**`, // 해당 경로 하위 모든 이미지 허용
  },
```
### 카카오 이미지 url을 와일드카드를 사용해서 전부 허용하도록 수정하였습니다.
```typescript
{
      protocol: 'http',
      hostname: '*.kakaocdn.net',
},
```

## 2. 빌드 중 Lint 미주입 문제

CI/CD Lint 단계에서 `.env`가 도커 이미지에 주입되지 않는 오류를 클라우드팀과 함께 해결하였습니다.
`fe-ci/cd.yml` 파일을 확인해주세요!

## 관련 이슈
Closes #279 
