### PR TITLE
PR:[fix] 참여한 챌린지 목록의 기간에 KST 적용

### DIFF
--- a/src/features/challenge/components/challenge-participant-card/challenge-participant-card.tsx
+++ b/src/features/challenge/components/challenge-participant-card/challenge-participant-card.tsx
@@ -9,13 +9,15 @@ import { AchievementRecord } from '@/entities/member/api'
 
 import { LucideIcon } from '@/shared/components'
 import { theme } from '@/shared/config'
+import { extractDateFromISOInKST } from '@/shared/lib'
+import { ISOFormatString } from '@/shared/type'
 
 interface ChallengeProps {
   className?: string
   imageUrl?: string
   title: string
-  startDate: Date
-  endDate: Date
+  startDate: ISOFormatString
+  endDate: ISOFormatString
   successCount: number
   maxCount: number
   record?: AchievementRecord[]
@@ -33,10 +35,6 @@ export const GroupChallengeParticipantCard = ({
   record = [],
   onClick,
 }: ChallengeProps): ReactNode => {
-  const formatDate = (date: Date): string => {
-    return date.toISOString().split('T')[0]
-  }
-
   const getColor = (status: FeedVerificationStatusType): string => {
     switch (status) {
       case 'SUCCESS':
@@ -68,7 +66,7 @@ export const GroupChallengeParticipantCard = ({
           <ArrowIcon onClick={onClick} name='ChevronRight' size={18} />
         </TitleSection>
         <DateRange>
-          {formatDate(startDate)} ~ {formatDate(endDate)}
+          {extractDateFromISOInKST(startDate)} ~ {extractDateFromISOInKST(endDate)}
         </DateRange>
         <InfoSection>
           <ProgressItem>

--- a/src/widgets/member/challenge/participate/list/member-challenge-participate-list.tsx
+++ b/src/widgets/member/challenge/participate/list/member-challenge-participate-list.tsx
@@ -84,8 +84,8 @@ export function ChallengeParticipatePage() {
               key={id}
               title={title}
               imageUrl={thumbnailUrl}
-              startDate={new Date(startDate)}
-              endDate={new Date(endDate)}
+              startDate={startDate}
+              endDate={endDate}
               successCount={achievement.success}
               maxCount={achievement.total}
               record={achievementRecords}


### PR DESCRIPTION
# 요약

> 작업내용을 간략히 작성합니다.
- 참여한 챌린지 목록의 기간에 KST 적용

# 변경사항

> 변경사항을 항목별로 자세히 작성합니다.

## 1. 참여한 챌린지 목록의 기간에 KST 적용
UTC로 받아온 데이터를 KST기준으로 변경합니다.

## 관련 이슈

Relates to #309 
Closes #309 
