### PR TITLE
CL : 모니터링 서비스 백그라운드 실행 코드로 변경 (Dockerfile)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ COPY --from=builder /app/next.config.ts ./next.config.ts
 USER nodejs
 
 EXPOSE 3000
+EXPOSE 9103
 
-CMD ["pnpm", "run", "start"]
-
+#CMD ["pnpm", "run", "start"]
+CMD sh -c "node scripts/metrics-server.ts & pnpm run start"


### PR DESCRIPTION
# 요약

> Dockerfile 수정

# 변경사항
- Dockerfile `CMD`를 수정하여 `metrics-server.ts`를 백그라운드로 실행하도록 변경
- `pnpm run start`와 함께 동시에 실행되도록 쉘 명령(`sh -c`) 사용
- Prometheus 메트릭 수집을 위한 9103 포트 EXPOSE 추가

## 1.

## 관련 이슈

Relates to #number
Closes #number
