### PR TITLE
feat: metrics-server.js 실행 추가 및 Dockerfile CMD 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,4 @@ EXPOSE 3000
 EXPOSE 9103
 
 #CMD ["pnpm", "run", "start"]
-CMD sh -c "node scripts/metrics-server.ts & pnpm run start"
+CMD sh -c "node scripts/metrics-server.js & pnpm run start"

--- a/scripts/metrics-server.js
+++ b/scripts/metrics-server.js
@@ -1,0 +1,20 @@
+// scripts/metrics-server.ts
+import http from 'http'
+
+import client from 'prom-client'
+
+client.collectDefaultMetrics({
+  labels: {
+    application_name: 'leafresh-frontend',
+    env: process.env.NEXT_PUBLIC_RUNTIME,
+  },
+})
+
+const server = http.createServer(async (_req, res) => {
+  res.setHeader('Content-Type', client.register.contentType)
+  res.end(await client.register.metrics())
+})
+
+server.listen(9103, '0.0.0.0', () => {
+  console.log('Prometheus metrics server running on port 9103')
+})


### PR DESCRIPTION
# 요약

> Prometheus 메트릭 수집을 위한 `metrics-server.js` 실행을 Dockerfile에 추가

# 변경사항

> 
## 1. Dockerfile 수정
- CMD를 `node scripts/metrics-server.js & pnpm run start`로 변경하여 Next.js와 메트릭 서버가 함께 실행되도록 구성
- 9103 포트 EXPOSE 추가 (Prometheus scrape용)

## 2. metrics-server.ts → metrics-server.js 변경
- 기존 파일에서 타입스크립트를 사용하지 않으므로 `.js` 파일로 변환
- tsconfig 구조 상 TypeScript 빌드가 불가능한 환경을 고려한 조치

