### PR TITLE
fix: 쿠키 설정을 도메인 생략으로 변경

### DIFF
--- a/src/app/api/next/cleanup-token/route.ts
+++ b/src/app/api/next/cleanup-token/route.ts
@@ -4,9 +4,7 @@ export async function DELETE() {
   return new NextResponse(null, {
     status: 200,
     headers: {
-      'Set-Cookie': [
-        `accessToken=deleted; Path=/; Domain=leafresh.app; Max-Age=0; HttpOnly; Secure; SameSite=None`,
-      ].join(', '),
+      'Set-Cookie': [`accessToken=deleted; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=None`].join(', '),
     },
   })
 }


### PR DESCRIPTION
# 요약

> 작업내용을 간략히 작성합니다.

기존 토큰을 삭제하는 API를 재구축하였습니다.

쿠키는 도메인이 일치하는 경우 서브 도메인으로 등록합니다. 
이는, RFC 6265 쿠키 스펙에서 명시된 내용입니다.

단, 쿠키 설정을 하지 않는 경우 기존 쿠키를 덮어쓸 수 있습니다. 따라서, 기존 구축했던 API Route의 쿠키 도메인을 삭제하였스빈다.

## 관련 이슈

Relates to #335
