### PR TITLE
PR FE (fix) : 나뭇잎 상점 개수 낙관적 업데이트 및 개수 예외 처리

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -28,7 +28,9 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'storage.googleapis.com', // 정확히 이 도메인이어야 함
-        pathname: `/${gcsHostname}/**`, // 해당 경로 하위 모든 이미지 허용
+        pathname: `/**`, // 해당 경로 하위 모든 이미지 허용
+
+        // pathname: `/${gcsHostname}/**`, // 해당 경로 하위 모든 이미지 허용
       },
       {
         protocol: 'http',

--- a/next.config.ts
+++ b/next.config.ts
@@ -28,9 +28,7 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'storage.googleapis.com', // 정확히 이 도메인이어야 함
-        pathname: `/**`, // 해당 경로 하위 모든 이미지 허용
-
-        // pathname: `/${gcsHostname}/**`, // 해당 경로 하위 모든 이미지 허용
+        pathname: `/${gcsHostname}/**`, // 해당 경로 하위 모든 이미지 허용
       },
       {
         protocol: 'http',

--- a/src/features/main/components/personal-challenge-section/personal-challenge-section.tsx
+++ b/src/features/main/components/personal-challenge-section/personal-challenge-section.tsx
@@ -230,6 +230,11 @@ const ScrollIcon = styled(LucideIcon)`
 `
 
 const StyledLeafReward = styled(LeafReward)`
-  top: 4%;
-  right: 9%;
+  background-color: ${({ theme }) => theme.colors.lfWhite.base};
+  border-radius: ${({ theme }) => theme.radius.md};
+
+  padding: 5px;
+  opacity: 0.8;
+  top: 3%;
+  right: 7%;
 `

--- a/src/features/store/components/ongoing-timedeal-card/ongoing-timedeal-card.tsx
+++ b/src/features/store/components/ongoing-timedeal-card/ongoing-timedeal-card.tsx
@@ -65,7 +65,7 @@ export const OngoingTimeDealCard = ({
     }
 
     // #2. 재고 부족
-    if (deal.stock <= 0) {
+    if (isSoldOut) {
       openToast(ToastType.Error, '품절된 상품입니다')
       return
     }

--- a/src/features/store/components/ongoing-timedeal-list/ongoing-timedeal-list.tsx
+++ b/src/features/store/components/ongoing-timedeal-list/ongoing-timedeal-list.tsx
@@ -72,7 +72,12 @@ export const OngoingTimeDealList = ({ data, memberLeafCount, className }: Props)
         <Embla ref={emblaRef}>
           <EmblaTrack>
             {data.map((deal, index) => (
-              <OngoingTimeDealCard key={deal.productId} data={deal} remainingSec={remainingTimes[index] ?? 0} />
+              <OngoingTimeDealCard
+                key={deal.productId}
+                data={deal}
+                remainingSec={remainingTimes[index] ?? 0}
+                memberLeafCount={memberLeafCount}
+              />
             ))}
           </EmblaTrack>
         </Embla>

--- a/src/features/store/components/ongoing-timedeal-list/ongoing-timedeal-list.tsx
+++ b/src/features/store/components/ongoing-timedeal-list/ongoing-timedeal-list.tsx
@@ -90,7 +90,7 @@ export const OngoingTimeDealList = ({ data, memberLeafCount, className }: Props)
       <TitleBox>
         <SectionTitle>🔥 지금만 이 가격</SectionTitle>
         <SubText>세상은 1등만 기억해!</SubText>
-        {memberLeafCount && <StyledLeafReward reward={memberLeafCount} />}
+        {memberLeafCount !== undefined && <StyledLeafReward reward={memberLeafCount} />}
       </TitleBox>
       {timeDealContents}
     </Container>

--- a/src/features/store/components/product-card/product-card.tsx
+++ b/src/features/store/components/product-card/product-card.tsx
@@ -25,9 +25,10 @@ import { ApiResponse } from '@/shared/lib'
 
 interface ProductCardProps {
   product: Product
+  memberLeafCount?: number
 }
 
-export const ProductCard = ({ product }: ProductCardProps) => {
+export const ProductCard = ({ product, memberLeafCount }: ProductCardProps) => {
   const router = useRouter()
   const queryClient = useQueryClient()
 
@@ -65,7 +66,16 @@ export const ProductCard = ({ product }: ProductCardProps) => {
     // #1. 에러 케이스
     // 재고 없음
     if (isSoldOut) {
-      openToast(ToastType.Error, '품절된 상품입니다.')
+      openToast(ToastType.Error, '품절된 상품입니다')
+      return
+    }
+
+    console.log('memberLeafcount : ', memberLeafCount)
+    console.log('상품 가격 : ', price)
+
+    // #2. 나뭇잎 개수 부족
+    if (memberLeafCount !== undefined && memberLeafCount < price) {
+      openToast(ToastType.Error, '나뭇잎 개수가 부족합니다')
       return
     }
 

--- a/src/features/store/components/product-card/product-card.tsx
+++ b/src/features/store/components/product-card/product-card.tsx
@@ -6,7 +6,9 @@ import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 
 import styled from '@emotion/styled'
+import { useQueryClient } from '@tanstack/react-query'
 
+import { MemberLeafCountResponse } from '@/entities/member/api'
 import {
   OrderProductBody,
   OrderProductHeaders,
@@ -15,10 +17,11 @@ import {
   Product,
 } from '@/entities/store/api'
 
-import { media, theme, MUTATION_KEYS, useMutationStore } from '@/shared/config'
+import { media, theme, MUTATION_KEYS, useMutationStore, QUERY_KEYS } from '@/shared/config'
 import { URL } from '@/shared/constants'
 import { ToastType, useConfirmModalStore, useIdempotencyKeyStore } from '@/shared/context'
 import { useAuth, useToast } from '@/shared/hooks'
+import { ApiResponse } from '@/shared/lib'
 
 interface ProductCardProps {
   product: Product
@@ -26,6 +29,8 @@ interface ProductCardProps {
 
 export const ProductCard = ({ product }: ProductCardProps) => {
   const router = useRouter()
+  const queryClient = useQueryClient()
+
   const openToast = useToast()
   const { isLoggedIn } = useAuth()
   const { openConfirmModal } = useConfirmModalStore()
@@ -77,6 +82,19 @@ export const ProductCard = ({ product }: ProductCardProps) => {
         const prevStock = localStock
         setLocalStock(prev => prev - 1)
 
+        const prevLeafData = queryClient.getQueryData<ApiResponse<MemberLeafCountResponse>>(QUERY_KEYS.MEMBER.LEAVES)
+
+        queryClient.setQueryData<ApiResponse<MemberLeafCountResponse>>(QUERY_KEYS.MEMBER.LEAVES, old => {
+          if (!old?.data) return old
+          return {
+            ...old,
+            data: {
+              ...old.data,
+              currentLeafPoints: old.data.currentLeafPoints - price,
+            },
+          }
+        })
+
         PurchaseMutate(
           { productId: id, headers, body },
           {
@@ -84,7 +102,12 @@ export const ProductCard = ({ product }: ProductCardProps) => {
               openToast(ToastType.Success, '구매가 완료되었습니다')
             },
             onError: () => {
-              setLocalStock(prevStock) // 실패 시 롤백
+              // 실패 시 롤백
+              setLocalStock(prevStock)
+              if (prevLeafData) {
+                queryClient.setQueryData(QUERY_KEYS.MEMBER.LEAVES, prevLeafData)
+              }
+
               openToast(ToastType.Error, '구매에 실패했습니다\n다시 시도해주세요')
             },
             onSettled: () => {

--- a/src/features/store/components/product-card/product-card.tsx
+++ b/src/features/store/components/product-card/product-card.tsx
@@ -130,7 +130,7 @@ export const ProductCard = ({ product }: ProductCardProps) => {
       <TextContent>
         <Title>{title}</Title>
         <Description>{description}</Description>
-        <StockNotice isSoldOut={isSoldOut}>{isSoldOut ? `남은 재고 없음` : `남은 재고 ${stock}개`}</StockNotice>
+        <StockNotice isSoldOut={isSoldOut}>{isSoldOut ? `남은 재고 없음` : `남은 재고 ${localStock}개`}</StockNotice>
         <PriceRow>
           <LeafIcon src='/icon/leaf.svg' alt='leaf' width={24} height={24} />
           <Price>{price.toLocaleString()}</Price>

--- a/src/features/store/components/product-list/product-list.tsx
+++ b/src/features/store/components/product-list/product-list.tsx
@@ -76,7 +76,7 @@ export const ProductList = ({ memberLeafCount, className }: ProductListProps): R
       <>
         <ProductGrid>
           {products.map(product => (
-            <ProductCard key={product.id} product={product} />
+            <ProductCard key={product.id} product={product} memberLeafCount={memberLeafCount} />
           ))}
           {isFetchingNextPage && <StyledLoading />}
           {hasNextPage && <ObserverTrigger ref={observerRef} />}

--- a/src/features/store/components/product-list/product-list.tsx
+++ b/src/features/store/components/product-list/product-list.tsx
@@ -96,7 +96,7 @@ export const ProductList = ({ memberLeafCount, className }: ProductListProps): R
           onChange={e => setInput(e.target.value)}
         />
       </SearchBar>
-      {memberLeafCount && (
+      {memberLeafCount !== undefined && (
         // <LeafCountWrapper>
         <StyledLeafReward reward={memberLeafCount} />
         // </LeafCountWrapper>


### PR DESCRIPTION
# 요약

> 작업내용을 간략히 작성합니다.

나뭇잎 상점에서 나뭇잎 개수가 추가됨에 따라, 상품 구매시 낙관적 업데이트 적용 및 나뭇잎 개수가 부족한 경우에 대한 예외처리를 토스트로 진행하였습니다.

# 변경사항

> 변경사항을 항목별로 자세히 작성합니다.

## 1. 나뭇잎 개수 낙관적 업데이트
업데이트 상황
- 일반 상품 구매
- 특가 상품 구매

## 2. 예외 처리
- 나뭇잎 개수가 부족한 경우, 구매 실패

## 3. 오류 처리
- 낙관적 업데이트에 따라, 재고 유무를 백엔드에서 받은 데이터가 아닌 낙관적 업데이트를 위해 관리하는 재고로 판단합니다.

---

Relates #341
Closes #342

