### PR TITLE
PR FE (fix): 나뭇잎 상점 페이지의 새로고침시 로그인 풀림 / OAuth 로그인 실패 상황 핸들링

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,16 +1,16 @@
 {
   "folder-color.pathColors": [
     {
-      "folderPath": "leafresh-fe/tests/",
-      "badge": "🟡"
-    },
-    {
       "folderPath": "leafresh-fe/src/widgets/",
       "badge": "🔴"
     },
     {
       "folderPath": "leafresh-fe/src/features/",
       "badge": "🟠"
+    },
+    {
+      "folderPath": "leafresh-fe/src/entities/",
+      "badge": "🟡"
     },
     {
       "folderPath": "leafresh-fe/src/shared/",

--- a/src/app/(with-layout)/(with-header)/member/login/page.tsx
+++ b/src/app/(with-layout)/(with-header)/member/login/page.tsx
@@ -57,7 +57,7 @@ const LoginPage = () => {
         window.location.href = parsedUrl.toString()
       }
     } catch (_error) {
-      toast('Error', `${provider} 로그인 실패\n재시도 해주세요`)
+      toast('Error', `로그인 실패\n재시도 해주세요`)
     }
   }
 

--- a/src/features/member/api/index.ts
+++ b/src/features/member/api/index.ts
@@ -1,4 +1,5 @@
 export * from './alarm'
+export * from './profile'
 export * from './store'
 
 // 파일

--- a/src/features/member/api/profile/index.ts
+++ b/src/features/member/api/profile/index.ts
@@ -1,0 +1,2 @@
+export * from './use-get-profile'
+export * from './use-validate-member-profile'

--- a/src/features/member/api/profile/use-get-profile.ts
+++ b/src/features/member/api/profile/use-get-profile.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { getMemberProfile } from '@/entities/member/api'
+
+import { QUERY_KEYS, QUERY_OPTIONS } from '@/shared/config'
+
+export const useGetMemberProfile = ({ enabled = true }: { enabled?: boolean }) => {
+  return useQuery({
+    queryKey: QUERY_KEYS.MEMBER.DETAILS,
+    queryFn: getMemberProfile,
+    ...QUERY_OPTIONS.MEMBER.DETAILS,
+    enabled,
+  })
+}

--- a/src/features/member/api/profile/use-validate-member-profile.ts
+++ b/src/features/member/api/profile/use-validate-member-profile.ts
@@ -1,0 +1,57 @@
+// use-validate-member-profile.ts
+import { useEffect, useState } from 'react'
+
+import { useUserStore } from '@/shared/context'
+import { UserInfo } from '@/shared/context'
+
+import { useGetMemberProfile } from './use-get-profile'
+
+interface UseValidateMemberProfileOptions {
+  enabled: boolean
+  onError?: (error: unknown) => void
+}
+
+/**
+ * JWT 토큰을 통해 로그인 상태를 최신화하는 훅
+ * @param enabled 실행 여부
+ * @param onError 에러 시 실행할 콜백 함수
+ * @returns isAuthVerified : 로그인 여부
+ */
+export const useValidateMemberProfile = ({ enabled, onError }: UseValidateMemberProfileOptions) => {
+  const { setUserInfo, clearUserInfo } = useUserStore()
+  const [isAuthVerified, setIsAuthVerified] = useState<boolean>(!enabled)
+
+  const { data, isSuccess, isError, error } = useGetMemberProfile({ enabled })
+
+  useEffect(() => {
+    if (!enabled) {
+      setIsAuthVerified(true)
+      return
+    }
+
+    if (isSuccess && data?.data) {
+      const { nickname, email, profileImageUrl, treeImageUrl, treeLevelId, treeLevelName } = data.data
+
+      const userInfo: UserInfo = {
+        nickname,
+        email,
+        imageUrl: profileImageUrl,
+        treeState: {
+          level: treeLevelId,
+          name: treeLevelName,
+          imageUrl: treeImageUrl,
+        },
+      }
+
+      setUserInfo(userInfo)
+      setIsAuthVerified(true)
+    }
+
+    if (isError) {
+      clearUserInfo()
+      onError?.(error)
+    }
+  }, [enabled, isSuccess, isError, data])
+
+  return { isAuthVerified }
+}

--- a/src/features/store/components/ongoing-timedeal-list/ongoing-timedeal-list.tsx
+++ b/src/features/store/components/ongoing-timedeal-list/ongoing-timedeal-list.tsx
@@ -6,11 +6,13 @@ import { useRouter } from 'next/navigation'
 
 import useEmblaCarousel from 'embla-carousel-react'
 
+import { useValidateMemberProfile } from '@/features/member/api'
+
 import { TimeDealProduct } from '@/entities/store/api'
 
 import { LucideIcon } from '@/shared/components'
 import { URL } from '@/shared/constants'
-import { useConfirmModalStore, useUserStore } from '@/shared/context'
+import { useConfirmModalStore } from '@/shared/context'
 import { useToast } from '@/shared/hooks'
 
 import { OngoingTimeDealCard } from '../ongoing-timedeal-card'
@@ -26,7 +28,9 @@ interface Props {
 
 export const OngoingTimeDealList = ({ ongoingData, upcomingData, memberLeafCount, className }: Props): ReactNode => {
   const router = useRouter()
-  const { isLoggedIn } = useUserStore()
+  // const { userInfo, isLoggedIn } = useUserStore()
+  const { isAuthVerified } = useValidateMemberProfile({ enabled: true }) // 로그인 상태 갱신을 위해
+
   const { toast } = useToast()
   const { openConfirmModal } = useConfirmModalStore()
 
@@ -48,7 +52,7 @@ export const OngoingTimeDealList = ({ ongoingData, upcomingData, memberLeafCount
       }
 
       // 타임딜 시작 60초 전 & 미로그인
-      if (!loginToastShownRef.current && !isLoggedIn && diff <= 60 && diff > 5) {
+      if (!loginToastShownRef.current && !isAuthVerified && diff <= 60 && diff > 5) {
         openConfirmModal({
           title: '타임딜이 곧 시작됩니다!',
           description: '로그인 페이지로 이동하시겠습니까?',
@@ -59,7 +63,7 @@ export const OngoingTimeDealList = ({ ongoingData, upcomingData, memberLeafCount
     }, 1000)
 
     return () => clearInterval(interval)
-  }, [ongoingData, upcomingData, isLoggedIn, toast])
+  }, [ongoingData, upcomingData, isAuthVerified, toast])
 
   /** 각 재고의 남은 시간 트래킹 */
   const [remainingTimes, setRemainingTimes] = useState<number[]>([]) // "초" 단위

--- a/src/widgets/member/oauth-callback/callback.tsx
+++ b/src/widgets/member/oauth-callback/callback.tsx
@@ -97,7 +97,8 @@ export const CallbackPage = ({ provider }: CallbackPageProps) => {
   }
 
   if (isError) {
-    // toast("Error", `${provider} 로그인 실패\n재시도 해주세요`)
+    toast('Error', `${provider} 로그인 실패\n재시도 해주세요`)
+    router.replace(URL.MEMBER.LOGIN.value)
 
     return <p>로그인 실패</p>
   }

--- a/src/widgets/member/oauth-callback/callback.tsx
+++ b/src/widgets/member/oauth-callback/callback.tsx
@@ -46,7 +46,7 @@ export const CallbackPage = ({ provider }: CallbackPageProps) => {
       })
     },
     ...QUERY_OPTIONS.MEMBER.AUTH.CALLBACK,
-    enabled: typeof code === 'string' && code.length > 0,
+    enabled: typeof code === 'string' && code.length > 0 && state !== null,
   })
 
   useEffect(() => {
@@ -88,21 +88,14 @@ export const CallbackPage = ({ provider }: CallbackPageProps) => {
     }
   }, [data])
 
-  if (isLoading) {
-    return (
-      <S.LoadingWrapper>
-        <Loading />
-      </S.LoadingWrapper>
-    )
-  }
-
   if (isError) {
     toast('Error', `${provider} 로그인 실패\n재시도 해주세요`)
     router.replace(URL.MEMBER.LOGIN.value)
-
-    return <p>로그인 실패</p>
   }
 
-  // 데이터 로드 후 라우팅될 것이므로 빈 상태 반환
-  return null
+  return (
+    <S.LoadingWrapper>
+      <Loading />
+    </S.LoadingWrapper>
+  )
 }

--- a/src/widgets/member/oauth-callback/styles.ts
+++ b/src/widgets/member/oauth-callback/styles.ts
@@ -1,10 +1,16 @@
 import styled from '@emotion/styled'
 
+import { Loading } from '@/shared/components'
+
 export const LoadingWrapper = styled.div`
   width: 100%;
-  height: 100dvh;
+  height: 100%;
 
   display: flex;
   align-items: center;
   justify-content: center;
+`
+
+export const StyledLoading = styled(Loading)`
+  height: 100%;
 `


### PR DESCRIPTION
# 요약

작업 내용을 간략히 정리합니다.

- 타임딜 상황에서 발생한 나뭇잎 상점 페이지의 로그인 상태 초기화 문제를 해결하였습니다.
- Dev 환경에서 OAuth 로그인 실패 이슈도 함께 해결하였습니다.

---

# 변경사항

주요 변경사항을 항목별로 자세히 작성합니다.

## 1. 나뭇잎 상점 페이지에서 로그인 상태 초기화 문제 해결

기존에는 `const { isLoggedIn } = useUserStore()`를 통해 로그인 여부를 판단했습니다.
하지만 나뭇잎 상점 페이지는 Protected Route가 아니고, `isLoggedIn` 값은 로컬 스토리지에 저장되지 않기 때문에, 새로고침 시 false로 초기화되는 문제가 있었습니다.

기존에는 `AuthGuard`에서 `getMemberProfile` API를 호출해 로그인 정보를 최신화했지만,
상점 페이지는 로그인하지 않아도 접근 가능한 페이지이므로, 로그인 여부만을 확인하기 위한 별도 처리가 필요했습니다.

이에 따라, AuthGuard에서 사용하던 `getMemberProfile`을 기반으로
**로그인 정보 최신화 전용 훅 `useValidateMemberProfile`**을 만들었습니다.

```tsx
interface UseValidateMemberProfileOptions {
  enabled: boolean
  onError?: (error: unknown) => void
}

/**
 * JWT 토큰을 통해 로그인 상태를 최신화하는 훅
 * @param enabled 실행 여부
 * @param onError 에러 시 실행할 콜백 함수
 * @returns isAuthVerified : 로그인 여부
 */
export const useValidateMemberProfile = ({ enabled, onError }: UseValidateMemberProfileOptions) => {
  const { setUserInfo, clearUserInfo } = useUserStore()
  const [isAuthVerified, setIsAuthVerified] = useState<boolean>(!enabled)

  const { data, isSuccess, isError, error } = useGetMemberProfile({ enabled })

  useEffect(() => {
    if (!enabled) {
      setIsAuthVerified(true)
      return
    }

    if (isSuccess && data?.data) {
      const { nickname, email, profileImageUrl, treeImageUrl, treeLevelId, treeLevelName } = data.data

      const userInfo: UserInfo = {
        nickname,
        email,
        imageUrl: profileImageUrl,
        treeState: {
          level: treeLevelId,
          name: treeLevelName,
          imageUrl: treeImageUrl,
        },
      }

      setUserInfo(userInfo)
      setIsAuthVerified(true)
    }

    if (isError) {
      clearUserInfo()
      onError?.(error)
    }
  }, [enabled, isSuccess, isError, data])

  return { isAuthVerified }
}
```

- AuthGuard에서는 이 훅의 onError 콜백을 통해 로그인 실패 시 로그인 페이지로 리디렉션하도록 구성했습니다.
- 상점 페이지처럼 로그인 여부만 확인하고 싶은 경우에는 onError 콜백 없이 사용 가능합니다.

## 2. OAuth 로그인 실패 문제 해결

OAuth 로그인 callback 페이지에서, 로컬 스토리지에 저장된 state 값을 불러오기 전에 useQuery가 먼저 실행되어 로그인에 실패하는 이슈가 있었습니다.

-이를 해결하기 위해 useQuery의 `enabled` 옵션에 state가 존재할 때만 요청하도록 조건을 추가하였습니다.

```tsx
 const { data, isLoading, isError } = useQuery({
    queryKey: QUERY_KEYS.MEMBER.AUTH.CALLBACK(provider),
    queryFn: () => {
      if (!code || !state) {
        return
      }
      return LoginCallback({
        provider,
        code,
        state,
      })
    },
    ...QUERY_OPTIONS.MEMBER.AUTH.CALLBACK,
    enabled: typeof code === 'string' && code.length > 0 && state !== null, // ✅ 추가됨
  })
``

또한, 로그인 프로세스 도중 Loading 컴포넌트가 위치를 이탈하는 현상이 있어, 레이아웃 안정성을 위한 위치 고정도 함께 처리했습니다.


## 관련 이슈

Closes #367
