### PR TITLE
PR FE (feat) : 단체 챌린지 참여 후, "인증 대기"로 라우팅 되도록 변경

### DIFF
--- a/src/app/(with-layout)/(with-header)/member/challenge/participate/list/page.tsx
+++ b/src/app/(with-layout)/(with-header)/member/challenge/participate/list/page.tsx
@@ -6,9 +6,13 @@ import { ChallengeStatus, getGroupParticipations, getGroupParticipationsCount } 
 
 import { getQueryClient, QUERY_KEYS, QUERY_OPTIONS } from '@/shared/config'
 
-export default async function Page() {
+interface PageProps {
+  params: Promise<{ status: ChallengeStatus }>
+}
+
+const Page = async ({ params }: PageProps) => {
   try {
-    const status: ChallengeStatus = 'ongoing'
+    const { status } = await params
 
     const queryClient = getQueryClient()
 
@@ -39,3 +43,5 @@ export default async function Page() {
     return <div>챌린지 정보를 불러오는 데 실패했습니다.</div>
   }
 }
+
+export default Page

--- a/src/shared/components/navbar/consts.ts
+++ b/src/shared/components/navbar/consts.ts
@@ -9,7 +9,7 @@ type Navbar_Tab = {
 }
 export const NAVBAR_TABS: Navbar_Tab[] = [
   { label: '챌린지', icon: 'CheckCheck', href: URL.MAIN.INDEX.value }, // 단체 챌린지 목록 페이지
-  { label: '인증', icon: 'Camera', href: URL.MEMBER.CHALLENGE.PARTICIPATE.LIST.value }, // 참여중인 챌린지
+  { label: '인증', icon: 'Camera', href: URL.MEMBER.CHALLENGE.PARTICIPATE.LIST.value('ongoing') }, // 참여중인 챌린지
   { label: '피드', icon: 'MessageCircleMore', href: URL.CHALLENGE.GROUP.FEED.value },
   { label: '상점', icon: 'ShoppingCart', href: URL.STORE.INDEX.value }, //
   { label: '마이페이지', icon: 'User', href: URL.MEMBER.PROFILE.MYPAGE.value },

--- a/src/shared/constants/route.ts
+++ b/src/shared/constants/route.ts
@@ -1,4 +1,7 @@
 import { ChallengeCategoryType } from '@/entities/challenge/model'
+import { ChallengeStatus } from '@/entities/member/api'
+
+import { buildURI } from '../lib'
 
 type URL = {
   name: string
@@ -14,40 +17,37 @@ const CHALLENGE_URL = {
   PERSONAL: {
     DETAILS: {
       name: '개인 챌린지 상세',
-      value: (personalId: number) => `/challenge/personal/${personalId}`,
-      dynamicPath: '/challenge/personal/[id]', // 👈 추가
+      value: (personalId: number) => buildURI(`/challenge/personal/${personalId}`),
+      dynamicPath: '/challenge/personal/[id]',
       isProtected: false,
       hasBackButton: true,
     },
   },
   GROUP: {
-    // TODO: 단체 챌린지 목록 페이지 제거하기
     LIST: {
       name: '단체 챌린지 목록',
-      value: (category?: ChallengeCategoryType) =>
-        category ? `/challenge/group/list?category=${category}` : '/challenge/group/list',
+      value: (category?: ChallengeCategoryType) => buildURI('/challenge/group/list', { query: { category } }),
       dynamicPath: '/challenge/group/list',
       isProtected: false,
       hasBackButton: true,
     },
     CREATE: {
       name: '단체 챌린지 생성',
-      value: (category?: ChallengeCategoryType) =>
-        category ? `/challenge/group/create?category=${category}` : `/challenge/group/create`,
+      value: (category?: ChallengeCategoryType) => buildURI('/challenge/group/create', { query: { category } }),
       dynamicPath: '/challenge/group/create',
       isProtected: true,
       hasBackButton: true,
     },
     MODIFY: {
       name: '단체 챌린지 수정',
-      value: (challengeId: number) => `/challenge/group/${challengeId}/modify`,
+      value: (challengeId: number) => buildURI(`/challenge/group/${challengeId}/modify`),
       dynamicPath: '/challenge/group/[challengeId]/modify',
       isProtected: true,
       hasBackButton: true,
     },
     DETAILS: {
       name: '단체 챌린지 상세',
-      value: (challengeId: number) => `/challenge/group/${challengeId}`,
+      value: (challengeId: number) => buildURI(`/challenge/group/${challengeId}`),
       dynamicPath: '/challenge/group/[challengeId]',
       isProtected: false,
       hasBackButton: true,
@@ -55,7 +55,7 @@ const CHALLENGE_URL = {
     VERIFICATION: {
       LIST: {
         name: '이용자 인증 내역 목록',
-        value: (challengeId: number) => `/challenge/group/${challengeId}/verification/list`,
+        value: (challengeId: number) => buildURI(`/challenge/group/${challengeId}/verification/list`),
         dynamicPath: '/challenge/group/[challengeId]/verification/list',
         isProtected: false,
         hasBackButton: true,
@@ -63,7 +63,7 @@ const CHALLENGE_URL = {
       DETAILS: {
         name: '챌린지 인증 상세',
         value: (challengeId: number, verificationId: number) =>
-          `/challenge/group/${challengeId}/verification/${verificationId}`,
+          buildURI(`/challenge/group/${challengeId}/verification/${verificationId}`),
         dynamicPath: '/challenge/group/[challengeId]/verification/[verificationId]',
         isProtected: false,
         hasBackButton: true,
@@ -71,7 +71,7 @@ const CHALLENGE_URL = {
     },
     FEED: {
       name: '챌린지 인증 피드',
-      value: `/challenge/group/feed`,
+      value: buildURI(`/challenge/group/feed`),
       isProtected: false,
       hasBackButton: false,
     },
@@ -81,7 +81,7 @@ const CHALLENGE_URL = {
 const MAIN_URL = {
   INDEX: {
     name: '메인',
-    value: '/',
+    value: buildURI('/'),
     isProtected: false,
     hasBackButton: false,
   } as URL,
@@ -90,75 +90,70 @@ const MAIN_URL = {
 const MEMBER_URL = {
   LOGIN: {
     name: '로그인',
-    value: '/member/login',
+    value: buildURI('/member/login'),
     isProtected: false,
     hasBackButton: true,
   },
   CALLBACK: {
     name: '소셜 로그인 콜백',
-    value: (provider: string) => `/member/${provider}/callback`,
+    value: (provider: string) => buildURI(`/member/${provider}/callback`),
     dynamicPath: '/member/[provider]/callback',
     isProtected: false,
     hasBackButton: false,
   },
   SIGNUP: {
     name: '회원가입',
-    value: '/member/signup',
+    value: buildURI('/member/signup'),
     isProtected: false,
     hasBackButton: true,
   },
   PROFILE: {
     MYPAGE: {
       name: '마이페이지',
-      value: '/member/profile/mypage',
+      value: buildURI('/member/profile/mypage'),
       isProtected: true,
       hasBackButton: false,
     },
-
     MODIFY: {
       name: '프로필 수정',
-      value: '/member/profile/modify',
+      value: buildURI('/member/profile/modify'),
       isProtected: true,
       hasBackButton: true,
     },
     BADGE: {
       name: '뱃지 조회',
-      value: '/member/profile/badge',
+      value: buildURI('/member/profile/badge'),
       isProtected: true,
       hasBackButton: true,
     },
   },
   ALARM: {
     name: '알림 확인',
-    value: '/member/alarm',
+    value: buildURI('/member/alarm'),
     isProtected: true,
     hasBackButton: true,
   },
   CHALLENGE: {
     PARTICIPATE: {
-      // 참여 중인 챌린지
       LIST: {
         name: '참여중인 챌린지',
-        value: `/member/challenge/participate/list`,
+        value: (status?: ChallengeStatus) => buildURI('/member/challenge/participate/list', { query: { status } }),
         isProtected: true,
         hasBackButton: false,
       },
     },
     VERIFICATION: {
-      // 특정 챌린지 인증 현황
       STATUS: {
         name: '특정 챌린지 인증 현황',
-        value: (challengeId: number) => `/member/challenge/${challengeId}/verification/status`,
+        value: (challengeId: number) => buildURI(`/member/challenge/${challengeId}/verification/status`),
         isProtected: true,
         hasBackButton: true,
       },
     },
-
     CREATE: {
-      // 생성한 챌린지
       LIST: {
         name: '생성한 챌린지',
-        value: '/member/challenge/create/list',
+        value: buildURI('/member/challenge/create/list'),
         isProtected: true,
         hasBackButton: true,
       },
@@ -167,7 +162,7 @@ const MEMBER_URL = {
   STORE: {
     PURCHASED: {
       name: '나뭇잎 상점 구매 목록',
-      value: '/member/store/list',
+      value: buildURI('/member/store/list'),
       isProtected: true,
       hasBackButton: true,
     },
@@ -177,7 +172,7 @@ const MEMBER_URL = {
 const STORE_URL = {
   INDEX: {
     name: '나뭇잎 상점',
-    value: `/store`,
+    value: buildURI('/store'),
     isProtected: false,
     hasBackButton: false,
   },

--- a/src/shared/lib/utils/build-uri.ts
+++ b/src/shared/lib/utils/build-uri.ts
@@ -1,0 +1,28 @@
+export interface UrlBuilderOptions {
+  query?: Record<string, string | number | boolean | undefined | null>
+  fragment?: string
+}
+
+/**
+ * 경로에 쿼리스트링과 해시(fragment)를 붙여주는 함수
+ * @param path 기본 URL 경로
+ * @param options query 객체, fragment 문자열
+ * @returns ex) '/challenge/group/list?category=food&page=2#section1'
+ */
+export const buildURI = (path: string, options?: UrlBuilderOptions): string => {
+  const { query, fragment } = options || {}
+  const searchParams = new URLSearchParams()
+
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && value !== null) {
+        searchParams.set(key, String(value))
+      }
+    }
+  }
+
+  const queryString = searchParams.toString()
+  const fullPath = queryString ? `${path}?${queryString}` : path
+
+  return fragment ? `${fullPath}#${fragment}` : fullPath
+}

--- a/src/shared/lib/utils/index.ts
+++ b/src/shared/lib/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './build-uri'
 export * from './copy-clipboard'
 export * from './theme-utils'

--- a/src/widgets/challenge/group/[id]/details/challenge-group-details.tsx
+++ b/src/widgets/challenge/group/[id]/details/challenge-group-details.tsx
@@ -144,7 +144,7 @@ export const ChallengeGroupDetails = ({ challengeId, className }: ChallengeGroup
       {
         onSuccess: () => {
           toast('Success', `참여 성공!\n인증 제출을 해주세요`) // 성공 메시지
-          router.replace(URL.MEMBER.CHALLENGE.PARTICIPATE.LIST.value) // 참여중인 챌린지로 이동
+          router.replace(URL.MEMBER.CHALLENGE.PARTICIPATE.LIST.value('not_started')) // 참여중인 챌린지로 이동
         },
       },
     )

--- a/src/widgets/member/challenge/participate/list/member-challenge-participate-list.tsx
+++ b/src/widgets/member/challenge/participate/list/member-challenge-participate-list.tsx
@@ -47,7 +47,6 @@ export function ChallengeParticipatePage() {
 
   const challenges = (challengeData?.pages ?? []).flatMap(page => page?.data?.challenges ?? [])
 
-  // const url = URL.CHALLENGE.PARTICIPATE.DETAILS
   const tabLabels = [
     `인증 대기 (${counts?.notStarted ?? 0})`,
     `진행 중 (${counts?.ongoing ?? 0})`,

--- a/src/widgets/member/challenge/participate/list/member-challenge-participate-list.tsx
+++ b/src/widgets/member/challenge/participate/list/member-challenge-participate-list.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 
 import { useQuery } from '@tanstack/react-query'
 
@@ -16,16 +16,30 @@ import { URL } from '@/shared/constants'
 
 import * as S from './styles'
 
-const statusMap: Record<number, ChallengeStatus> = {
+const statusMap: Record<ChallengeStatus, number> = {
+  not_started: 0,
+  ongoing: 1,
+  completed: 2,
+}
+const reverseStatusMap: Record<number, ChallengeStatus> = {
   0: 'not_started',
   1: 'ongoing',
   2: 'completed',
 }
 
 export function ChallengeParticipatePage() {
-  const [tab, setTab] = useState(1)
-  const status = statusMap[tab]
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const status: ChallengeStatus = (searchParams.get('status') as ChallengeStatus) || 'ongoing'
+
+  const [tab, setTab] = useState(statusMap[status])
+
+  /** 탭 변경 핸들러 */
+  const handleChangeTab = (tab: number) => {
+    const status = reverseStatusMap[tab]
+    setTab(tab)
+    router.push(URL.MEMBER.CHALLENGE.PARTICIPATE.LIST.value(status))
+  }
 
   // 실제 API 훅
   const {
@@ -109,7 +123,7 @@ export function ChallengeParticipatePage() {
   return (
     <S.Container>
       <S.SwitchTapContainer>
-        <SwitchTap tabs={tabLabels} currentIndex={tab} onChange={setTab} />
+        <SwitchTap tabs={tabLabels} currentIndex={tab} onChange={handleChangeTab} />
       </S.SwitchTapContainer>
 
       <S.CardListContainer isChallengeExists={isChallengeExists}>

--- a/src/widgets/member/challenge/verification/status/member-challenge-verification-status.tsx
+++ b/src/widgets/member/challenge/verification/status/member-challenge-verification-status.tsx
@@ -94,12 +94,12 @@ export function GroupVerificationPage({ challengeId }: { challengeId: number }) 
   }
 
   const renderButton = () => {
-    if (isCompleted) return <S.DisabledButton>기간 종료</S.DisabledButton>
+    if (isCompleted) return <S.DisabledButton>챌린지 기간 종료</S.DisabledButton>
     switch (verifications.todayStatus) {
       case 'NOT_SUBMITTED':
         return <S.ActionButton onClick={handleCapture}>인증하기</S.ActionButton>
       case 'PENDING_APPROVAL':
-        return <S.DisabledButton>인증 중</S.DisabledButton>
+        return <S.DisabledButton>AI 인증 판단중</S.DisabledButton>
       case 'DONE':
         return <S.DisabledButton>오늘 참여 완료</S.DisabledButton>
       default:


### PR DESCRIPTION
# 요약

> 작업 내용을 간략히 정리합니다.

단체 챌린지에 참여한 직후, 사용자가 해당 챌린지를 확인할 수 없는 탭으로 라우팅되는 문제가 있었습니다.
사용자 혼란을 줄이기 위해, 참여 직후 “인증 대기” 탭으로 이동하도록 개선하였으며, 이를 위해 status 값을 URL 쿼리 파라미터로 추가하도록 구현했습니다.

# 변경사항

> 변경사항을 항목별로 자세히 작성합니다.

## 1. buildURI 유틸 함수 추가

`buildURI` 함수는 `query`와 `fragment` 값을 받아, 이를 포함한 URI 문자열을 생성합니다.
이제부터 query 또는 fragment를 포함한 URL을 생성할 때는 아래 함수를 사용해주세요.

```tsx
export interface UrlBuilderOptions {
  query?: Record<string, string | number | boolean | undefined | null>
  fragment?: string
}

/**
 * 경로에 쿼리스트링과 해시(fragment)를 붙여주는 함수
 * @param path 기본 URL 경로
 * @param options query 객체, fragment 문자열
 * @returns ex) '/challenge/group/list?category=food&page=2#section1'
 */
export const buildURI = (path: string, options?: UrlBuilderOptions): string => {
  const { query, fragment } = options || {}
  const searchParams = new URLSearchParams()

  if (query) {
    for (const [key, value] of Object.entries(query)) {
      if (value !== undefined && value !== null) {
        searchParams.set(key, String(value))
      }
    }
  }

  const queryString = searchParams.toString()
  const fullPath = queryString ? `${path}?${queryString}` : path

  return fragment ? `${fullPath}#${fragment}` : fullPath
}
```

## 2. 인증 페이지에 status 쿼리 파라미터 추가

단체 챌린지 참여 직후, 기본적으로 status=not_started 탭으로 이동되도록 변경했습니다.
이로써 사용자가 방금 참여한 챌린지를 바로 확인할 수 있게 되었습니다.

## 관련 이슈
Closes #371
