### PR TITLE
PR FE (fix) :  SSR 이후 CSR에서 불필요한 refetch 제거

### DIFF
--- a/src/app/(with-layout)/(with-header)/page.tsx
+++ b/src/app/(with-layout)/(with-header)/page.tsx
@@ -18,22 +18,25 @@ const Page = async () => {
     const dayOfWeek: DayType = getDayOfWeek(now)
 
     await Promise.all([
-      queryClient.prefetchQuery({
-        queryKey: QUERY_KEYS.CHALLENGE.GROUP.CATEGORIES,
-        queryFn: getGroupChallengeCategoryList,
-        ...QUERY_OPTIONS.CHALLENGE.GROUP.CATEGORIES,
-      }),
-
+      // 이벤트 챌린지 목록
       queryClient.prefetchQuery({
         queryKey: QUERY_KEYS.CHALLENGE.EVENT.LIST,
         queryFn: getEventChallengeList,
         ...QUERY_OPTIONS.CHALLENGE.EVENT.LIST,
       }),
 
+      // 개인 챌린지 목록
       queryClient.prefetchQuery({
         queryKey: QUERY_KEYS.CHALLENGE.PERSONAL.LIST(dayOfWeek),
         queryFn: () => getPersonalChallengeList({ dayOfWeek }),
         ...QUERY_OPTIONS.CHALLENGE.PERSONAL.LIST,
+      }),
+
+      // 단체 챌린지 카테고리 목록
+      queryClient.prefetchQuery({
+        queryKey: QUERY_KEYS.CHALLENGE.GROUP.CATEGORIES,
+        queryFn: getGroupChallengeCategoryList,
+        ...QUERY_OPTIONS.CHALLENGE.GROUP.CATEGORIES,
       }),
     ])
 

--- a/src/shared/config/tanstack-query/query-client.ts
+++ b/src/shared/config/tanstack-query/query-client.ts
@@ -7,6 +7,7 @@ const options = {
     queries: {
       retry: 0,
       refetchOnWindowFocus: false,
+      ...(isServer ? { gcTime: Infinity } : {}), // TC의 서버에서는 gcTime = Infinity인 경우 요청이 종료되면 자동으로 GC를 수행한다.
       ...QUERY_DEFAULT,
     },
     mutations: {

--- a/src/shared/config/tanstack-query/query-client.ts
+++ b/src/shared/config/tanstack-query/query-client.ts
@@ -1,12 +1,13 @@
 import { isServer, QueryClient } from '@tanstack/react-query'
 
+import { QUERY_DEFAULT } from './query-defaults'
+
 const options = {
   defaultOptions: {
     queries: {
       retry: 0,
       refetchOnWindowFocus: false,
-      staleTime: 0, // 즉시 무효화 처리 (지정한 경우에만 즉시 캐싱)
-      gcTime: 1000 * 60 * 5, // 언마운트 후 5분 동안 메모리 캐시 유지
+      ...QUERY_DEFAULT,
     },
     mutations: {
       retry: 0, // 실패시 재시도하지 않음 (필요시 지정)

--- a/src/shared/config/tanstack-query/query-defaults.ts
+++ b/src/shared/config/tanstack-query/query-defaults.ts
@@ -1,8 +1,12 @@
-const getMinute = (minute: number) => {
+export const getSecond = (second: number) => {
+  return 1000 * second
+}
+
+export const getMinute = (minute: number) => {
   return 1000 * 60 * minute
 }
 
-const getHour = (hour: number) => {
+export const getHour = (hour: number) => {
   return 1000 * 60 * 60 * hour
 }
 
@@ -10,8 +14,8 @@ const NO_CACHE = {
   staleTime: 0,
   gcTime: 0,
 }
-const DEFAULT = {
-  staleTime: 0,
+export const QUERY_DEFAULT = {
+  staleTime: getSecond(1),
   gcTime: getMinute(5),
 }
 
@@ -40,7 +44,7 @@ const CHALLENGE_QUERY_DEFAULTS = {
       gcTime: getHour(24),
     },
     // 인증 결과 조회 (롱폴링)
-    VERIFICATION_RESULT: DEFAULT,
+    VERIFICATION_RESULT: QUERY_DEFAULT,
   },
 
   /** 단체 챌린지 */
@@ -51,24 +55,24 @@ const CHALLENGE_QUERY_DEFAULTS = {
       gcTime: Infinity,
     },
     // 상세
-    DETAILS: DEFAULT,
+    DETAILS: QUERY_DEFAULT,
     // 목록 (검색 포함)
-    LIST: DEFAULT,
+    LIST: QUERY_DEFAULT,
 
     // 규약 조회
-    RULES: DEFAULT,
+    RULES: QUERY_DEFAULT,
 
     VERIFICATION: {
       // 인증 내역 목록 조회
-      LIST: DEFAULT,
+      LIST: QUERY_DEFAULT,
 
       // 인증 결과 조회 (롱폴링)
-      RESULT: DEFAULT,
+      RESULT: QUERY_DEFAULT,
 
       //인증 상세
       DETAILS: NO_CACHE,
       //인증 댓글
-      COMMENT: DEFAULT,
+      COMMENT: QUERY_DEFAULT,
     },
 
     // 인증 내역 목록 조회 (피드) - 무작위 챌린지
@@ -91,9 +95,9 @@ const MEMBER_QUERY_DEFAULTS = {
   DUPLICATE_NICKNAME: NO_CACHE,
 
   // 회원 정보
-  DETAILS: DEFAULT,
-  PROFILE_CARD: DEFAULT,
-  LEAVES: DEFAULT,
+  DETAILS: QUERY_DEFAULT,
+  PROFILE_CARD: QUERY_DEFAULT,
+  LEAVES: QUERY_DEFAULT,
   FEEDBACK: {
     GET_FEEDBACK: {
       staleTime: getHour(24),
@@ -113,13 +117,13 @@ const MEMBER_QUERY_DEFAULTS = {
 
   // 알림
   NOTIFICATION: {
-    LIST: DEFAULT,
+    LIST: QUERY_DEFAULT,
   },
 
   // 나뭇잎 상점
   STORE: {
     ORDERS: {
-      LIST: DEFAULT,
+      LIST: QUERY_DEFAULT,
     },
   },
 
@@ -127,16 +131,16 @@ const MEMBER_QUERY_DEFAULTS = {
   CHALLENGE: {
     GROUP: {
       // 생성한 챌린지
-      CREATIONS: DEFAULT,
+      CREATIONS: QUERY_DEFAULT,
 
       // 참여한 단체 챌린지 카운트
-      COUNT: DEFAULT,
+      COUNT: QUERY_DEFAULT,
 
       // 내가 참여한 챌린지
-      PARTICIPATIONS: DEFAULT,
+      PARTICIPATIONS: QUERY_DEFAULT,
 
       // 인증 내역을 일별로 확인
-      VERIFICATIONS: DEFAULT,
+      VERIFICATIONS: QUERY_DEFAULT,
     },
   },
 }
@@ -144,11 +148,11 @@ const MEMBER_QUERY_DEFAULTS = {
 const STORE_QUERY_DEFAULTS = {
   TIME_DEAL: {
     // 타임딜 상품 목록
-    LIST: DEFAULT,
+    LIST: QUERY_DEFAULT,
   },
   PRODUCTS: {
     // 일반 상품 목록
-    LIST: DEFAULT,
+    LIST: QUERY_DEFAULT,
   },
   ETC: {
     COUNT: {

--- a/src/shared/config/tanstack-query/query-defaults.ts
+++ b/src/shared/config/tanstack-query/query-defaults.ts
@@ -14,6 +14,7 @@ const NO_CACHE = {
   staleTime: 0,
   gcTime: 0,
 }
+
 export const QUERY_DEFAULT = {
   staleTime: getSecond(1),
   gcTime: getMinute(5),

--- a/src/widgets/challenge/group/[id]/verification/details/challenge-group-verification-details.tsx
+++ b/src/widgets/challenge/group/[id]/verification/details/challenge-group-verification-details.tsx
@@ -58,9 +58,6 @@ export const VerificationDetails = ({
     queryKey: QUERY_KEYS.CHALLENGE.GROUP.VERIFICATION.DETAILS(challengeId, verificationId),
     queryFn: () => getVerificationDetails({ challengeId, verificationId }),
     ...QUERY_OPTIONS.CHALLENGE.GROUP.VERIFICATION.DETAILS,
-    // enabled: isClient,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
   })
 
   const { data: commentData } = useQuery({


### PR DESCRIPTION
<h1>요약</h1>
<blockquote>
<p>작업내용을 간략히 작성합니다.</p>
</blockquote>
<p>SSR에서 prefetchQuery로 데이터를 미리 받아왔음에도, 클라이언트에서 동일한 쿼리를 중복 요청하는 문제를 해결했습니다.</p>
<h2>변경사항</h2>
<blockquote>
<p>변경사항을 항목별로 자세히 작성합니다.</p>
</blockquote>
<h2><strong>1. staleTime 기본값을 0이 아닌 값으로 설정</strong></h2>
<p>테스트 결과, CSR의 staleTime이 0보다 크면 <strong>SSR에서 미리 패칭된 데이터</strong>를 그대로 재사용하고, <strong>중복 요청이 발생하지 않는 것</strong>을 확인했습니다.</p>

SSR (prefetchQuery) StaleTime | CSR (useQuery) StaleTime | CSR 리페치 여부
-- | -- | --
0 | 0 | ⭕️
0 | not 0 | ❌
not 0 | 0 | ⭕️
not 0 | not 0 | ❌


<p>기존에는 Tanstack Query 기본 설정대로 <code>staleTime: 0</code>을 사용해왔으나,</p>
<p>이는 SSR에서 받은 데이터를 클라이언트가 곧바로 <strong>stale 상태로 간주</strong>하게 되어, 리페치가 발생하는 원인이었습니다.</p>
<h3>어떤 값으로 설정?</h3>
<ul>
<li><code>staleTime</code>을 너무 크게 설정하면 최신 데이터 반영이 늦어지며</li>
<li>다시 0으로 두면 중복 요청 문제가 발생하므로,</li>
<li><strong>사용자가 체감하기 어려운 (주관적) 최소 단위인 “1분”으로 설정</strong>했습니다.</li>
</ul>
<p>이를 통해 SSR 캐시를 재사용하면서도, 사용자는 최신 데이터를 적절히 받아볼 수 있도록 조정했습니다.</p>

<br><br>

<h2>2. SSR gcTime = Infinity 설정</h2>
<p>공식 문서를 참고한 결과, SSR에서 <code>gcTime</code>을 <code>Infinity</code>로 설정하면</p>
<p><strong>요청 종료 시 자동으로 가비지 컬렉션이 수행</strong>된다고 안내하고 있습니다.</p>

### [공식 문서 링크](https://github.com/100-hours-a-week/15-Leafresh-FE/pull/378#issue-3226269251)
<p>또한, <code>gcTime: 0</code>으로 설정할 경우에는 <strong>Hydration mismatch 오류</strong>가 발생할 수 있으며,</p>
<blockquote>
<p>이는, “Hydration 시 충분한 시간이 보장되지 않으면, SSR/CSR 간 데이터 불일치로 에러 발생”</p>
</blockquote>

<img width="755" height="479" alt="image" src="https://github.com/user-attachments/assets/f71bb4db-00a6-4cca-b8a0-cb79e0a3a75a" />


<p>또한 “React Query Devtools”에서 간헐적으로 발생하던 오류의 원인일 가능성도 있습니다.</p>
<p>따라서 SSR에서 사용하는 <code>QueryClient</code>는 다음과 같이 설정했습니다:</p>
<pre><code class="language-tsx">const options = {
  defaultOptions: {
    queries: {
      retry: 0,
      refetchOnWindowFocus: false,
      ...(isServer ? { gcTime: Infinity } : {}), // TC의 서버에서는 gcTime = Infinity인 경우 요청이 종료되면 자동으로 GC를 수행한다.
      ...QUERY_DEFAULT,
    },
    mutations: {
      retry: 0, // 실패시 재시도하지 않음 (필요시 지정)
    },
  },
}

</code></pre>
<h2>관련 이슈</h2>
Closes #377</p>
<!-- notionvc: 8b49b677-4f7f-4d46-9f72-f080ec3b6193 -->