### PR TITLE
fix: 서버 환경에서 gcTime 기본 설정 적용되도록 순서 변경

### DIFF
--- a/src/shared/config/tanstack-query/query-client.ts
+++ b/src/shared/config/tanstack-query/query-client.ts
@@ -7,8 +7,8 @@ const options = {
     queries: {
       retry: 0,
       refetchOnWindowFocus: false,
-      ...(isServer ? { gcTime: Infinity } : {}), // TC의 서버에서는 gcTime = Infinity인 경우 요청이 종료되면 자동으로 GC를 수행한다.
       ...QUERY_DEFAULT,
+      ...(isServer ? { gcTime: Infinity } : {}), // TC의 서버에서는 gcTime = Infinity인 경우 요청이 종료되면 자동으로 GC를 수행한다.
     },
     mutations: {
       retry: 0, // 실패시 재시도하지 않음 (필요시 지정)


### PR DESCRIPTION
# 요약

> 작업내용을 간략히 작성합니다.

서버의 gcTime이 적용되기 위해 구조분해할당 코드의 위치를 수정하였습니다.

이전
```tsx
const options = {
  defaultOptions: {
    queries: {
      retry: 0,
      refetchOnWindowFocus: false,
      ...(isServer ? { gcTime: Infinity } : {}), // ❌
      ...QUERY_DEFAULT,
    },
    mutations: {
      retry: 0, // 실패시 재시도하지 않음 (필요시 지정)
    },
  },
}
```


이후
```tsx
const options = {
  defaultOptions: {
    queries: {
      retry: 0,
      refetchOnWindowFocus: false,
      ...QUERY_DEFAULT,
      ...(isServer ? { gcTime: Infinity } : {}), // ✅
    },
    mutations: {
      retry: 0, // 실패시 재시도하지 않음 (필요시 지정)
    },
  },
}
```
