### PR TITLE
Fix: CI/CD 중 lint, unit 테스트가 merge 이후에 실행되지 않도록 변경

### DIFF
--- a/.github/workflows/fe-cicd.yml
+++ b/.github/workflows/fe-cicd.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   setup:
     name: Setup and Install Dependencies
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
     outputs:
       pnpm_cache_hit: ${{ steps.cache-pnpm.outputs.cache-hit }}
@@ -40,7 +40,7 @@ jobs:
 
   lint-and-unit-test:
     name: Lint and Unit test
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     needs: [setup]
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
# 요약

> lint and unit test 작업이 merge 이후에도 실행되는 상황 해결

# 변경사항

> setup, lint and unit test 작업의 if 구문을 PR 상태만 확인하던 상태에서, closed를 제외한 모든 PR 상황에 실행하도록 변경
