### PR TITLE
Fix: gcloud info 커맨드 수정

### DIFF
--- a/.github/workflows/fe-cicd.yml
+++ b/.github/workflows/fe-cicd.yml
@@ -250,8 +250,7 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v2'
 
       - name: Verify The Installation of gcloud CLI
-        run: |
-          'gcloud info'
+        run: gcloud info
 
       - name: Upload via IAP SCP to FE PROD server
         run: |


### PR DESCRIPTION
# 요약

> gcloud info 커맨드 수정

# 변경사항

> gcloud cli 테스트 용도인 gcloud info 커맨드 양 옆에 있는 작은 따옴표 삭제
