### PR TITLE
Fix: gcloud info 커맨드 수정 (#394)

### DIFF
--- a/.github/workflows/fe-cicd.yml
+++ b/.github/workflows/fe-cicd.yml
@@ -250,8 +250,7 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v2'
 
       - name: Verify The Installation of gcloud CLI
-        run: |
-          'gcloud info'
+        run: gcloud info
 
       - name: Upload via IAP SCP to FE PROD server
         run: |


### PR DESCRIPTION
Fix: gcloud info

# 요약

> gcloud info 커맨드 수정

# 변경사항

> 1. gcloud info 실행 오류: 커맨드 양쪽 옆에 작은 따옴표가 있었음<br>&rarr; 작은 따옴표 기호 삭제
