### PR TITLE
PR FE (fix): 피드 리스트 무한스크롤 옵저버 해제

### DIFF
--- a/src/features/challenge/components/feed-list/feed-list.tsx
+++ b/src/features/challenge/components/feed-list/feed-list.tsx
@@ -51,7 +51,8 @@ export const FeedList = ({ category, className }: FeedListProps): ReactNode => {
 
     return () => {
       if (observerRef.current) {
-        observer.unobserve(observerRef.current)
+        observer.disconnect()
+        // observer.unobserve(observerRef.current)
       }
     }
   }, [hasNextPage, isFetchingNextPage, fetchNextPage])


### PR DESCRIPTION
# 요약

> 작업내용을 간략히 작성합니다.

피드 페이지에서 사용중인 무한스크롤 옵저버의 메모리를 할당하는 로직 추가


## 관련 이슈
Relates to #373
