### PR TITLE
fix: 나뭇잎 개수가 0개인 경우에도 정상적 렌더링 표시

### DIFF
--- a/src/features/store/components/ongoing-timedeal-list/ongoing-timedeal-list.tsx
+++ b/src/features/store/components/ongoing-timedeal-list/ongoing-timedeal-list.tsx
@@ -141,7 +141,7 @@ export const OngoingTimeDealList = ({ ongoingData, upcomingData, memberLeafCount
       <S.TitleBox>
         <S.SectionTitle>🔥 지금만 이 가격</S.SectionTitle>
         <S.SubText>세상은 1등만 기억해!</S.SubText>
-        {memberLeafCount && <S.StyledLeafReward reward={memberLeafCount} />}
+        {memberLeafCount !== undefined && <S.StyledLeafReward reward={memberLeafCount} />}
       </S.TitleBox>
       {timeDealContents}
     </S.Container>


### PR DESCRIPTION
# 요약

> 작업내용을 간략히 작성합니다.

나뭇잎 개수가 0인 경우, falsy로 판단되어 `LeafReward` 컴포넌트가 정상 렌더링되지 않는 오류를 해결했습니다.

<img width="155" height="102" alt="image" src="https://github.com/user-attachments/assets/08f439cc-948e-4747-9ffc-fda68576e7be" />


# 변경사항

> 변경사항을 항목별로 자세히 작성합니다.

`undefined`인 경우를 분기처리하도록 하였습니다.
```tsx
{/* {memberLeafCount && <S.StyledLeafReward reward={memberLeafCount} />} */}
        {memberLeafCount !== undefined && <S.StyledLeafReward reward={memberLeafCount} />}
```

## 관련 이슈
Relates to #341
Closes #407
