### PR TITLE
프론트엔드(DEV)용 Helm 차트 추가

### DIFF
--- a/helm/frontend/.helmignore
+++ b/helm/frontend/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/frontend/Chart.yaml
+++ b/helm/frontend/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: leafresh-fe
+description: A Helm chart for Leafresh Frontend
+type: application
+version: 0.1.0
+appVersion: "v2.1.37-dev

--- a/helm/frontend/templates/_helpers.tpl
+++ b/helm/frontend/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/*
+Return the name of the chart
+*/}}
+{{- define "leafresh-fe.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Return the full name (for unique resource naming)
+*/}}
+{{- define "leafresh-fe.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "leafresh-fe.labels" -}}
+app.kubernetes.io/name: {{ include "leafresh-fe.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "leafresh-fe.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "leafresh-fe.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Return the service account name
+*/}}
+{{- define "leafresh-fe.serviceAccountName" -}}
+{{- if .Values.serviceAccount.name }}
+{{ .Values.serviceAccount.name }}
+{{- else }}
+{{ include "leafresh-fe.fullname" . }}
+{{- end }}
+{{- end }}

--- a/helm/frontend/templates/deployment.yaml
+++ b/helm/frontend/templates/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "leafresh-fe.fullname" . }}
+  labels:
+    app: {{ include "leafresh-fe.name" . }}
+spec:
+  replicas: {{ .Values.autoscaling.enabled | ternary 1 .Values.autoscaling.minReplicas }}
+  selector:
+    matchLabels:
+      app: {{ include "leafresh-fe.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "leafresh-fe.name" . }}
+    spec:
+      containers:
+        - name: frontend
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+              name: http
+          env:
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}

--- a/helm/frontend/templates/hpa.yaml
+++ b/helm/frontend/templates/hpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "leafresh-fe.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "leafresh-fe.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/frontend/templates/ingress.yaml
+++ b/helm/frontend/templates/ingress.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "leafresh-fe.fullname" . }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  {{- if .Values.ingress.tlsEnabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ include "leafresh-fe.fullname" . }}-tls
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "leafresh-fe.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/helm/frontend/templates/service.yaml
+++ b/helm/frontend/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "leafresh-fe.fullname" . }}
+  labels:
+    {{- include "leafresh-fe.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "leafresh-fe.selectorLabels" . | nindent 4 }}

--- a/helm/frontend/templates/serviceaccount.yaml
+++ b/helm/frontend/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "leafresh-fe.serviceAccountName" . }}
+  labels:
+    {{- include "leafresh-fe.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/frontend/values.yaml
+++ b/helm/frontend/values.yaml
@@ -1,0 +1,60 @@
+image:
+  repository: 886436932852.dkr.ecr.ap-northeast-2.amazonaws.com/leafresh-fe
+  tag: v2.1.37-dev
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 3000
+
+env:
+  - name: NEXT_PUBLIC_RUNTIME
+    value: "dev"
+  - name: NEXT_PUBLIC_GOOGLE_ANALYTICS
+    value: "G-2BKG11WDXZ"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: 3000
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 2
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: 3000
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 2
+
+ingress:
+  enabled: true
+  host: "localhost.test"
+  path: /
+  pathType: Prefix
+  tlsEnabled: false
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: false        # 기본적으로 생성하지 않도록 설정 (불필요할 경우)
+  name: ""             # 필요 시 특정 이름 설정
+  automount: false     # 기본적으로 토큰 자동 마운트하지 않음
+  annotations: {}      # 필요한 경우 여기에 IAM Role 등 annotation 추가 가능


### PR DESCRIPTION
# 요약

> 프론트엔드(Next.js) 애플리케이션을 EKS에 배포하기 위해 Helm Chart를 추가 (이번 PR은 DEV 환경용 Helm Chart를 기준으로 작성)

# 변경사항

> 
- `helm/frontend/Chart.yaml` 추가
  - Chart 메타데이터(이름, 버전, 의존성 등) 정의
- `helm/frontend/templates/` 디렉토리 추가
  - Deployment, Service, HPA, Ingress 등 K8s 리소스 템플릿 생성
  - Secret 템플릿 추가 (`secret.yaml`)
- `helm/frontend/values.yaml` 추가
  - DEV 환경 기본값 및 리소스 요청/제한 설정

## 1.

Helm Chart 구조 생성
- K8s 리소스를 Helm 템플릿으로 관리할 수 있도록 Chart 구조 생성
- `values.yaml`을 통해 환경별 override 가능하도록 설계

## 관련 이슈

Relates to #number
Closes #number
