### PR TITLE
수정: HPA 활성화 시 replicas 필드 제거 (프론트엔드)

### DIFF
--- a/helm/frontend/templates/deployment.yaml
+++ b/helm/frontend/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     app: {{ include "leafresh-fe.name" . }}
 spec:
-  replicas: {{ .Values.autoscaling.enabled | ternary 1 .Values.autoscaling.minReplicas }}
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.autoscaling.minReplicas }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ include "leafresh-fe.name" . }}


### PR DESCRIPTION
# 요약

> Helm Chart(frontend)에서 HPA 사용 시 `replicas` 값이 항상 Deployment에 포함되어 OutOfSync가 발생하는 문제를 수정했습니다.

# 변경사항

> deployment.yaml 수정
- `replicas` 필드가 autoscaling.enabled=true인 경우 생성되지 않도록 조건문 추가
- autoscaling.enabled=false일 때만 minReplicas 값이 replicas로 들어가도록 수정

## 1.

## 관련 이슈

Relates to #number
Closes #number
